### PR TITLE
Add or modify Makefile recipes to enable regeneration of *.rdf files and retain expected *.ttl files content

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: Build and Run Tests
-        run: mvn clean install
+        run: make install unit-tests
       - name: current dir
         run: pwd
       - name: current dir

--- a/.gitignore
+++ b/.gitignore
@@ -325,3 +325,4 @@ lib64
 pyvenv.cfg
 /build/
 /node_modules/
+.temp

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,8 @@ TURTLE_FILELIST=$(shell ls ${ONTOLOGY_FOLDER_PATH}/*.ttl)
 # Widoco variables
 WIDOCO_RDF_INPUT_FILE_PATH?=test/reasoning-investigation/model-2020-12-16/ePO_restrictions.rdf
 WIDOCO_OUTPUT_FOLDER_PATH?=output/widoco
-NAMESPACES_AS_RDFPIPE_ARGS=$(shell ${MODEL2OWL_FOLDER}/scripts/get_namespaces.sh)
+NAMESPACES_XML_FILE_PATH?=${MODEL2OWL_FOLDER}/test/ePO-default-config/namespaces.xml
+NAMESPACES_AS_RDFPIPE_ARGS=$(shell ${MODEL2OWL_FOLDER}/scripts/get_namespaces.sh ${NAMESPACES_XML_FILE_PATH})
 RDF_XML_MIME_TYPE:='application/rdf+xml'
 TURTLE_MIME_TYPE:='turtle'
 

--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,10 @@ generate-glossary:
 	@echo Input file path: ${XMI_INPUT_FILE_PATH}
 	@echo Input file name: ${XMI_INPUT_FILENAME_WITHOUT_EXTENSION}
 	@cp -rf ./src/static "${OUTPUT_GLOSSARY_PATH}"
-	@java -jar ${SAXON} -s:${XMI_INPUT_FILE_PATH} -xsl:${MODEL2OWL_FOLDER}/src/html-model-glossary.xsl -o:${OUTPUT_GLOSSARY_PATH}/${XMI_INPUT_FILENAME_WITHOUT_EXTENSION}_glossary.html
+	@java -jar ${SAXON} -s:${XMI_INPUT_FILE_PATH} \
+		-xsl:${MODEL2OWL_FOLDER}/src/html-model-glossary.xsl \
+		-o:${OUTPUT_GLOSSARY_PATH}/${XMI_INPUT_FILENAME_WITHOUT_EXTENSION}_glossary.html \
+		enrichedNamespacesPath="${ENRICHED_NAMESPACES_XML_PATH}"
 	@echo The glossary is located at the following location:
 	@echo
 	@ls -lh ${OUTPUT_GLOSSARY_PATH}/${XMI_INPUT_FILENAME_WITHOUT_EXTENSION}_glossary.html
@@ -104,7 +107,10 @@ generate-convention-report:
 	@echo Input file path: ${XMI_INPUT_FILE_PATH}
 	@echo Input file name: ${XMI_INPUT_FILENAME_WITHOUT_EXTENSION}
 	@cp -rf ./src/static "${OUTPUT_CONVENTION_REPORT_PATH}"
-	@java -jar ${SAXON} -s:${XMI_INPUT_FILE_PATH} -xsl:${MODEL2OWL_FOLDER}/src/html-conventions-report.xsl -o:${OUTPUT_CONVENTION_REPORT_PATH}/${XMI_INPUT_FILENAME_WITHOUT_EXTENSION}_convention_report.html
+	@java -jar ${SAXON} -s:${XMI_INPUT_FILE_PATH} \
+		-xsl:${MODEL2OWL_FOLDER}/src/html-conventions-report.xsl \
+		-o:${OUTPUT_CONVENTION_REPORT_PATH}/${XMI_INPUT_FILENAME_WITHOUT_EXTENSION}_convention_report.html \
+		enrichedNamespacesPath="${ENRICHED_NAMESPACES_XML_PATH}"
 	@echo The convention report is located at the following location:
 	@echo
 	@ls -lh ${OUTPUT_CONVENTION_REPORT_PATH}/${XMI_INPUT_FILENAME_WITHOUT_EXTENSION}_convention_report.html
@@ -116,7 +122,10 @@ generate-convention-SVRL-report:
 	@echo Input file path: ${XMI_INPUT_FILE_PATH}
 	@echo Input file name: ${XMI_INPUT_FILENAME_WITHOUT_EXTENSION}
 	@cp -rf ./src/static "${OUTPUT_CONVENTION_REPORT_PATH}"
-	@java -jar ${SAXON} -s:${XMI_INPUT_FILE_PATH} -xsl:${MODEL2OWL_FOLDER}/src/svrl-conventions-report.xsl -o:${OUTPUT_CONVENTION_REPORT_PATH}/${XMI_INPUT_FILENAME_WITHOUT_EXTENSION}_convention_svrl_report.xml
+	@java -jar ${SAXON} -s:${XMI_INPUT_FILE_PATH} \
+		-xsl:${MODEL2OWL_FOLDER}/src/svrl-conventions-report.xsl \
+		-o:${OUTPUT_CONVENTION_REPORT_PATH}/${XMI_INPUT_FILENAME_WITHOUT_EXTENSION}_convention_svrl_report.xml \
+		enrichedNamespacesPath="${ENRICHED_NAMESPACES_XML_PATH}"
 	@echo The convention report is located at the following location:
 	@echo
 	@ls -lh ${OUTPUT_CONVENTION_REPORT_PATH}/${XMI_INPUT_FILENAME_WITHOUT_EXTENSION}_convention_svrl_report.xml

--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,11 @@ unit-tests:
 	@make test-prerequisites
 	@mvn install -Dsaxon.options.enrichedNamespacesPath=${ENRICHED_NAMESPACES_XML_PATH}
 
+# Actions required in order to setup the environment for testing purposes.
+# Usage (`[]` denotes an optional argument; if omited, default value will be used):
+# make test-prerequisites [NAMESPACES_USER_XML_FILE_PATH=/path/to/namespaces.xml]
+# where:
+#   NAMESPACES_USER_XML_FILE_PATH: path to the *.xml file provided by a user
 test-prerequisites:
 	@make gen-enriched-ns-file
 
@@ -84,6 +89,13 @@ create-virtual-env:
 
 
 # Generate the glossary from an input file
+# Usage (`[]` denotes an optional argument; if omited, default value will be used):
+# make generate-glossary [XMI_INPUT_FILE_PATH=/path/to/cm.xmi] 
+#	[OUTPUT_GLOSSARY_PATH=/output/directory]
+#	[NAMESPACES_USER_XML_FILE_PATH=/path/to/namespaces.xml]
+# where:
+#   NAMESPACES_USER_XML_FILE_PATH: path to the *.xml file provided by a user
+#
 # Example when not using the default variables
 # make generate-glossary XMI_INPUT_FILE_PATH=/home/mypc/work/model2owl/eNotice_CM.xml OUTPUT_GLOSSARY_PATH=/home/mypc/work/model2owl/glossary
 generate-glossary:
@@ -101,6 +113,14 @@ generate-glossary:
 	@ls -lh ${OUTPUT_GLOSSARY_PATH}/${XMI_INPUT_FILENAME_WITHOUT_EXTENSION}_glossary.html
 	@echo
 
+# Usage of the convention report generation recipes (generate-convention-report | generate-convention-SVRL-report).
+# `[]` denotes an optional argument; if omited, default value will be used:
+# make (generate-convention-report | generate-convention-SVRL-report) 
+#	[XMI_INPUT_FILE_PATH=/path/to/cm.xmi] 
+#	[OUTPUT_CONVENTION_REPORT_PATH=/output/directory]
+#	[NAMESPACES_USER_XML_FILE_PATH=/path/to/namespaces.xml]
+# where:
+#   NAMESPACES_USER_XML_FILE_PATH: path to the *.xml file provided by a user
 generate-convention-report:
 	@mkdir -p "${OUTPUT_CONVENTION_REPORT_PATH}"
 	@make gen-enriched-ns-file
@@ -130,7 +150,17 @@ generate-convention-SVRL-report:
 	@echo
 	@ls -lh ${OUTPUT_CONVENTION_REPORT_PATH}/${XMI_INPUT_FILENAME_WITHOUT_EXTENSION}_convention_svrl_report.xml
 	@echo
-#Example how to run transformation commands :
+
+
+# Usage of the transformation recipes (owl-core | owl-restrictions | shacl).
+# `[]` denotes an optional argument; if omited, default value will be used:
+# make (owl-core | owl-restrictions | shacl) [XMI_INPUT_FILE_PATH=/path/to/cm.xmi] 
+#	[OUTPUT_FOLDER_PATH=/output/directory]
+#	[NAMESPACES_USER_XML_FILE_PATH=/path/to/namespaces.xml]
+# where:
+#   NAMESPACES_USER_XML_FILE_PATH: path to the *.xml file provided by a user
+#
+# Example:
 # make owl-core XMI_INPUT_FILE_PATH=/home/mypc/work/model2owl/eNotice_CM.xml OUTPUT_FOLDER_PATH=./my-folder
 owl-core:
 	@make gen-enriched-ns-file
@@ -173,6 +203,10 @@ shacl:
 
 # Generate enriched namespaces XML file which contains user namespaces (defined
 # in namespaces.xml) and internal namespaces (such as core-shape)
+# Usage (`[]` denotes an optional argument; if omited, default value will be used):
+# make gen-enriched-ns-file [NAMESPACES_USER_XML_FILE_PATH=/path/to/namespaces.xml]
+# where:
+#   NAMESPACES_USER_XML_FILE_PATH: path to the *.xml file provided by a user
 gen-enriched-ns-file:
 	@mkdir -p ${INTERM_FOLDER_PATH}
 	@java -jar ${SAXON} -s:${NAMESPACES_USER_XML_FILE_PATH} -xsl:${MODEL2OWL_FOLDER}/src/xml/enriched-namespaces.xsl \
@@ -192,9 +226,14 @@ merge-xmi:
 
 
 
-#Example how to run converting commands :
-# make convert-to-turtle ONTOLOGY_FOLDER_PATH=./my-folder
-# ONTOLOGY_FOLDER_PATH is the the path to the folder containing .rdf files for converting to turtle or .ttl files to convert to rdf
+# Example how to run converting commands (`[]` denotes an optional argument;
+#  if omited, default value will be used):
+# make convert-to-turtle [ONTOLOGY_FOLDER_PATH=./my-folder] 
+#	[NAMESPACES_USER_XML_FILE_PATH=/path/to/namespaces.xml]
+# where:
+# ONTOLOGY_FOLDER_PATH: the path to the folder containing .rdf files for 
+#						converting to turtle or .ttl files to convert to rdf
+# NAMESPACES_USER_XML_FILE_PATH: path to the *.xml file provided by a user
 convert-rdf-to-turtle:
 	@make gen-enriched-ns-file
 	@for FILE_PATH in ${RDF_FILELIST}; do \

--- a/Makefile
+++ b/Makefile
@@ -68,12 +68,16 @@ get-widoco:
 ######################################################################################
 # Download, install saxon, xspec, rdflib and other dependencies
 ######################################################################################
-install:  get-saxon get-rdflib get-widoco
+install:  get-saxon create-virtual-env get-rdflib get-widoco
 
 ############################ Main tasks ##############################################
 # Run unit_tests
 unit-tests:
+	@make test-prerequisites
 	@mvn install -Dsaxon.options.enrichedNamespacesPath=${ENRICHED_NAMESPACES_XML_PATH}
+
+test-prerequisites:
+	@make gen-enriched-ns-file
 
 create-virtual-env:
 	@python -m venv model2owl-venv
@@ -84,6 +88,7 @@ create-virtual-env:
 # make generate-glossary XMI_INPUT_FILE_PATH=/home/mypc/work/model2owl/eNotice_CM.xml OUTPUT_GLOSSARY_PATH=/home/mypc/work/model2owl/glossary
 generate-glossary:
 	@mkdir -p "${OUTPUT_GLOSSARY_PATH}"
+	@make gen-enriched-ns-file
 	@echo Input file path: ${XMI_INPUT_FILE_PATH}
 	@echo Input file name: ${XMI_INPUT_FILENAME_WITHOUT_EXTENSION}
 	@cp -rf ./src/static "${OUTPUT_GLOSSARY_PATH}"
@@ -95,6 +100,7 @@ generate-glossary:
 
 generate-convention-report:
 	@mkdir -p "${OUTPUT_CONVENTION_REPORT_PATH}"
+	@make gen-enriched-ns-file
 	@echo Input file path: ${XMI_INPUT_FILE_PATH}
 	@echo Input file name: ${XMI_INPUT_FILENAME_WITHOUT_EXTENSION}
 	@cp -rf ./src/static "${OUTPUT_CONVENTION_REPORT_PATH}"
@@ -106,6 +112,7 @@ generate-convention-report:
 
 generate-convention-SVRL-report:
 	@mkdir -p "${OUTPUT_CONVENTION_REPORT_PATH}"
+	@make gen-enriched-ns-file
 	@echo Input file path: ${XMI_INPUT_FILE_PATH}
 	@echo Input file name: ${XMI_INPUT_FILENAME_WITHOUT_EXTENSION}
 	@cp -rf ./src/static "${OUTPUT_CONVENTION_REPORT_PATH}"
@@ -180,6 +187,7 @@ merge-xmi:
 # make convert-to-turtle ONTOLOGY_FOLDER_PATH=./my-folder
 # ONTOLOGY_FOLDER_PATH is the the path to the folder containing .rdf files for converting to turtle or .ttl files to convert to rdf
 convert-rdf-to-turtle:
+	@make gen-enriched-ns-file
 	@for FILE_PATH in ${RDF_FILELIST}; do \
 		echo Converting $${FILE_PATH} into Turtle; \
 		source model2owl-venv/bin/activate; \

--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ install:  get-saxon get-rdflib get-widoco
 ############################ Main tasks ##############################################
 # Run unit_tests
 unit-tests:
-	@mvn install
+	@mvn install -Dsaxon.options.enrichedNamespacesPath=${ENRICHED_NAMESPACES_XML_PATH}
 
 create-virtual-env:
 	@python -m venv model2owl-venv

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
                     <generateSurefireReport>true</generateSurefireReport>
                     <xspecProperties>
                         <xspec.fail>false</xspec.fail>
+                        <saxon.custom.options>enrichedNamespacesPath=${saxon.options.enrichedNamespacesPath}</saxon.custom.options>
                     </xspecProperties>
                 </configuration>
 <!--                <dependencies>-->

--- a/scripts/get_namespaces.sh
+++ b/scripts/get_namespaces.sh
@@ -1,15 +1,23 @@
 #!/bin/bash
 # 
-# Gets namespaces from namespaces.xml file and prepares argument
-# list from them to be used with `rdfpipe` tool.
-# Uses Saxon installed in the project main directory.
+# Gets namespaces from an XML file with the model2owl project namespaces
+# (`namespaces.xml` by default) and prepares argument list from them to be
+# used with `rdfpipe` tool. Uses Saxon installed in the project main directory.
+# 
+# USAGE: get_namespaces.sh NAMESPACES_XML_FILE_PATH
 
-PROJECT_DIR=$(dirname $(dirname $(realpath ${BASH_SOURCE[0]})))
-NAMESPACES_DIR=${PROJECT_DIR}/test/ePO-default-config
+if [ -z "$1" ]; then
+	echo "ERROR: path to *.xml file with namespaces not given."
+	exit 1
+fi
+namespaces_file_path="$1"
 
-cd ${NAMESPACES_DIR}
+namespaces_file_dir=$(dirname $(realpath $namespaces_file_path))
+namespaces_file_name=$(basename $namespaces_file_path)
+
+cd ${namespaces_file_dir}
 namespaces=$(
-    java -cp ../../saxon/saxon.jar net.sf.saxon.Query -s:namespaces.xml \
+    java -cp ../../saxon/saxon.jar net.sf.saxon.Query -s:${namespaces_file_name} \
 		-qs:'for $x in /*:prefixes/*:prefix return concat(string($x/@name), "=", string($x/@value))' \
 		\!method=text
 )

--- a/scripts/get_namespaces.sh
+++ b/scripts/get_namespaces.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# 
+# Gets namespaces from namespaces.xml file and prepares argument
+# list from them to be used with `rdfpipe` tool.
+# Uses Saxon installed in the project main directory.
+
+PROJECT_DIR=$(dirname $(dirname $(realpath ${BASH_SOURCE[0]})))
+NAMESPACES_DIR=${PROJECT_DIR}/test/ePO-default-config
+
+cd ${NAMESPACES_DIR}
+namespaces=$(
+    java -cp ../../saxon/saxon.jar net.sf.saxon.Query -s:namespaces.xml \
+		-qs:'for $x in /*:prefixes/*:prefix return concat(string($x/@name), "=", string($x/@value))' \
+		\!method=text
+)
+ns_args=$( \
+	echo "$namespaces" | tr ' ' '\n' | awk '{printf("--ns='\''%s'\'' ", $0)}'
+)
+
+echo "$ns_args"

--- a/scripts/get_namespaces.sh
+++ b/scripts/get_namespaces.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
 # 
-# Gets namespaces from an XML file with the model2owl project namespaces
-# (`namespaces.xml` by default) and prepares argument list from them to be
-# used with `rdfpipe` tool. Uses Saxon installed in the project main directory.
+# Gets namespaces from an XML file with the model2owl project namespaces and
+# prepares argument list from them to be used with `rdfpipe` tool. Uses Saxon
+# installed in the project main directory.
 # 
 # USAGE: get_namespaces.sh NAMESPACES_XML_FILE_PATH
+PROJECT_DIR=$(dirname $(dirname $(realpath ${BASH_SOURCE[0]})))
+SAXON=${PROJECT_DIR}/saxon/saxon.jar
 
 if [ -z "$1" ]; then
 	echo "ERROR: path to *.xml file with namespaces not given."
@@ -17,7 +19,7 @@ namespaces_file_name=$(basename $namespaces_file_path)
 
 cd ${namespaces_file_dir}
 namespaces=$(
-    java -cp ../../saxon/saxon.jar net.sf.saxon.Query -s:${namespaces_file_name} \
+    java -cp $SAXON net.sf.saxon.Query -s:${namespaces_file_name} \
 		-qs:'for $x in /*:prefixes/*:prefix return concat(string($x/@name), "=", string($x/@value))' \
 		\!method=text
 )

--- a/src/common/checkers.xsl
+++ b/src/common/checkers.xsl
@@ -512,15 +512,15 @@
     </xsl:function>
 
     <xd:doc>
-        <xd:desc> This function will check if a given list of namespaces are defined in
-            namespaces.xml file. If not all the namespaces were defined it will return a list with
-            those namespaces</xd:desc>
+        <xd:desc> This function will check if a given list of namespaces are
+        defined in enriched-namespaces.xml file. If not all the namespaces were
+        defined it will return a list with those namespaces</xd:desc>
         <xd:param name="listOfNamespaces"/>
     </xd:doc>
     <xsl:function name="f:isAllNamespacesDefined">
         <xsl:param name="listOfNamespaces"/>
         <xsl:variable name="definedNamespaces"
-            select="($namespacePrefixes/*:prefixes/*:prefix/@name)"/>
+            select="($internalNamespacePrefixes/*:prefixes/*:prefix/@name)"/>
         <xsl:variable name="listOfNotDefinedNamespaces"
             select="functx:value-except($listOfNamespaces, $definedNamespaces)"/>
         <xsl:sequence

--- a/src/common/utils.xsl
+++ b/src/common/utils.xsl
@@ -21,6 +21,13 @@
     <xsl:import href="fetchers.xsl"/>
     <xsl:import href="functx-1.0.1-doc.xsl"/>
 
+    <xsl:param name="enrichedNamespacesPath"/>
+    <xsl:variable name="internalNamespacePrefixes" select="
+        if (boolean($enrichedNamespacesPath)) then
+            fn:doc($enrichedNamespacesPath)
+        else fn:error(xs:QName('missing-parameter'), 'enrichedNamespacesPath is not given.')
+    "/>
+
     <xd:doc>
         <xd:desc> Lookup a data-type in the xsd and rdf accepted data-type document (usually an
             external file with xsd and rdf data-types definitions) and return false or the data-type
@@ -61,7 +68,7 @@
     <xsl:function name="f:getNamespaceURI" as="xs:string">
         <xsl:param name="prefix"/>
 
-        <xsl:variable name="fetch" select="f:getNamespaceValues($prefix, $namespacePrefixes)"/>
+        <xsl:variable name="fetch" select="f:getNamespaceValues($prefix, $internalNamespacePrefixes)"/>
         <xsl:sequence
             select="
                 if (boolean($fetch)) then
@@ -491,5 +498,14 @@
                     fn:true()"
         />
     </xsl:function>
+
+    <xd:doc>
+        <xd:desc>This template declares set of namespaces to be defined in top element of an output file</xd:desc>
+    </xd:doc>
+    <xsl:template name="namespacesDeclaration">
+        <xsl:for-each select="$internalNamespacePrefixes/*:prefixes/*:prefix">              
+            <xsl:namespace name="{./@name}" select="./@value"/>
+        </xsl:for-each>
+    </xsl:template>
 
 </xsl:stylesheet>

--- a/src/owl-core.xsl
+++ b/src/owl-core.xsl
@@ -46,9 +46,7 @@
     </xd:doc>
     <xsl:template match="/">
         <rdf:RDF>
-            <xsl:for-each select="$namespacePrefixes/*:prefixes/*:prefix">              
-                <xsl:namespace name="{./@name}" select="./@value"/>
-            </xsl:for-each>   
+            <xsl:call-template name="namespacesDeclaration"/>
             <xsl:call-template name="ontology-header"/>
             <xsl:apply-templates/>
             <xsl:call-template name="generalisationsWithDistinctTargetsInCoreLayer"/>
@@ -63,7 +61,7 @@
     <xsl:template name="ontology-header">
 
         <owl:Ontology rdf:about="{$coreArtefactURI}">         
-            <xsl:for-each select="$namespacePrefixes/*:prefixes/*:prefix/@importURI">              
+            <xsl:for-each select="$internalNamespacePrefixes/*:prefixes/*:prefix/@importURI">              
                 <owl:imports rdf:resource="{.}"/>
             </xsl:for-each>      
              

--- a/src/owl-restrictions.xsl
+++ b/src/owl-restrictions.xsl
@@ -40,11 +40,7 @@
     </xd:doc>
     <xsl:template match="/">
         <rdf:RDF>
-            <xsl:for-each select="$namespacePrefixes/*:prefixes/*:prefix">              
-                <xsl:namespace name="{./@name}" select="./@value"/>
-            </xsl:for-each>
-            <xsl:namespace name="{fn:concat($moduleReference, '-res')}" select="fn:concat($base-restriction-uri,$defaultDelimiter)"/>
-            
+            <xsl:call-template name="namespacesDeclaration"/>            
             <xsl:call-template name="ontology-header"/>
             <xsl:apply-templates/>
             <xsl:call-template name="generalisationsWithDistinctTargetsInReasoningLayer"/>
@@ -58,7 +54,7 @@
     </xd:doc>
     <xsl:template name="ontology-header">
         <owl:Ontology rdf:about="{$restrictionsArtefactURI}">            
-            <xsl:for-each select="$namespacePrefixes/*:prefixes/*:prefix/@importURI">              
+            <xsl:for-each select="$internalNamespacePrefixes/*:prefixes/*:prefix/@importURI">              
                 <owl:imports rdf:resource="{.}"/>
             </xsl:for-each>      
             <owl:imports rdf:resource="{$coreArtefactURI}"/>

--- a/src/shacl-shapes.xsl
+++ b/src/shacl-shapes.xsl
@@ -44,13 +44,7 @@
     </xd:doc>
     <xsl:template match="/">
         <rdf:RDF>
-            <xsl:for-each select="$namespacePrefixes/*:prefixes/*:prefix">              
-                <xsl:namespace name="{./@name}" select="./@value"/>
-            </xsl:for-each>
-            <xsl:namespace name="{fn:concat($moduleReference, '-res')}" select="fn:concat($base-restriction-uri,$defaultDelimiter)"/>
-            <xsl:namespace name="{fn:concat($moduleReference, '-shape')}" select="fn:concat($base-shape-uri,$defaultDelimiter)"/>
-            
-            
+            <xsl:call-template name="namespacesDeclaration"/>
             <xsl:call-template name="ontology-header"/>
             <xsl:apply-templates/>
         </rdf:RDF>
@@ -62,7 +56,7 @@
     <xsl:template name="ontology-header">
         <owl:Ontology rdf:about="{$shapeArtefactURI}">
             
-            <xsl:for-each select="$namespacePrefixes/*:prefixes/*:prefix/@importURI">              
+            <xsl:for-each select="$internalNamespacePrefixes/*:prefixes/*:prefix/@importURI">              
                 <owl:imports rdf:resource="{.}"/>
             </xsl:for-each>      
             <owl:imports rdf:resource="{$coreArtefactURI}"/>

--- a/src/xml/enriched-namespaces.xsl
+++ b/src/xml/enriched-namespaces.xsl
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns="http://publications.europa.eu/ns/"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:xd="http://www.oxygenxml.com/ns/doc/xsl" 
+    xmlns:fn="http://www.w3.org/2005/xpath-functions"
+    exclude-result-prefixes="xd xsl fn"
+    version="3.0">
+
+    <xsl:import href="../../config-proxy.xsl"/>
+    <xsl:output version="1.0" encoding="UTF-8" indent="yes" /> 
+
+    <xd:doc>
+        <xd:desc>
+            A template for generating enriched namespaces XML file that
+            contains internal model2owl namespaces which are constructed
+            based on the model2owl configuration.
+        </xd:desc>
+    </xd:doc>
+    <xsl:template match="/">
+        <prefixes>
+            <xsl:for-each select="/*:prefixes/*:prefix">
+                <prefix name="{./@name}" value="{./@value}">
+                    <xsl:if test="boolean(./@importURI)">
+                        <xsl:attribute name="importURI">
+                            <xsl:value-of select="./@importURI" />
+                        </xsl:attribute>
+                    </xsl:if>
+                </prefix>
+            </xsl:for-each>
+            <prefix name="{fn:concat($moduleReference, '-res')}" 
+                value="{fn:concat($base-restriction-uri,$defaultDelimiter)}"/>
+            <prefix name="{fn:concat($moduleReference, '-shape')}" 
+                value="{fn:concat($base-shape-uri,$defaultDelimiter)}"/>
+        </prefixes>
+    </xsl:template>
+</xsl:stylesheet>

--- a/test/ePO-default-config/namespaces.xml
+++ b/test/ePO-default-config/namespaces.xml
@@ -12,13 +12,18 @@
     <prefix name="dct" value="http://purl.org/dc/terms/" importURI="http://purl.org/dc/terms/"/>
     <prefix name="org" value="http://www.w3.org/ns/org#"/>
     <prefix name="skos" value="http://www.w3.org/2004/02/skos/core#" importURI="http://www.w3.org/2004/02/skos/core#"/>
+    <prefix name="eli" value="http://data.europa.eu/eli/ontology#"/>
 
     <prefix name="epo" value="http://data.europa.eu/a4g/ontology#"/>
+    <prefix name="epo-acc" value="http://data.europa.eu/a4g/ontology#"/>
     <prefix name="epo-cat" value="http://data.europa.eu/a4g/ontology#"/>
     <prefix name="epo-con" value="http://data.europa.eu/a4g/ontology#"/>
-    <prefix name="epo-ord" value="http://data.europa.eu/a4g/ontology#"/>
-    <prefix name="epo-not" value="http://data.europa.eu/a4g/ontology#"/>
     <prefix name="epo-ful" value="http://data.europa.eu/a4g/ontology#"/>
+    <prefix name="epo-inv" value="http://data.europa.eu/a4g/ontology#"/>
+    <prefix name="epo-not" value="http://data.europa.eu/a4g/ontology#"/>
+    <prefix name="epo-ord" value="http://data.europa.eu/a4g/ontology#"/>
+    <prefix name="epo-sub" value="http://data.europa.eu/a4g/ontology#"/>
+    <prefix name="core-shape" value="http://data.europa.eu/a4g/data-shape#"/>
 
     <prefix name="nuts" value="http://data.europa.eu/nuts/"/>
     <prefix name="reg2015" value="http://data.europa.eu/a4g/extension/ontology#"/>
@@ -26,12 +31,12 @@
     <prefix name="at-voc" value="http://publications.europa.eu/resource/authority/"/>
     <prefix name="time" value="http://www.w3.org/2006/time#"/>
     <prefix name="locn" value="http://www.w3.org/ns/locn#"/>
+    <prefix name="cccev" value="http://data.europa.eu/m8g/" importURI="https://data.europa.eu/m8g"/>
     <prefix name="cv" value="http://data.europa.eu/m8g/" importURI="https://data.europa.eu/m8g"/>
     <prefix name="core" value="http://data.europa.eu/m8g/"/>
     <prefix name="cpv" value="http://data.europa.eu/m8g/"/>
     <prefix name="cpsv" value="http://data.europa.eu/m8g/"/>
     <prefix name="cpov" value="http://data.europa.eu/m8g/"/>
-    <prefix name="cccev" value="http://data.europa.eu/m8g/" importURI="https://data.europa.eu/m8g"/>
     <prefix name="geosparql" value="http://www.opengis.net/ont/geosparql#"/>
     <prefix name="dul" value="http://www.loa-cnr.it/ontologies/DUL.owl#"/>    
     <prefix name="person" value="http://www.w3.org/ns/person#"/>

--- a/test/ePO-default-config/namespaces.xml
+++ b/test/ePO-default-config/namespaces.xml
@@ -23,7 +23,6 @@
     <prefix name="epo-not" value="http://data.europa.eu/a4g/ontology#"/>
     <prefix name="epo-ord" value="http://data.europa.eu/a4g/ontology#"/>
     <prefix name="epo-sub" value="http://data.europa.eu/a4g/ontology#"/>
-    <prefix name="core-shape" value="http://data.europa.eu/a4g/data-shape#"/>
 
     <prefix name="nuts" value="http://data.europa.eu/nuts/"/>
     <prefix name="reg2015" value="http://data.europa.eu/a4g/extension/ontology#"/>

--- a/test/unitTests/test-xml/test-enriched-namespaces.xspec
+++ b/test/unitTests/test-xml/test-enriched-namespaces.xspec
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+    xmlns:fn="http://www.w3.org/2005/xpath-functions"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    stylesheet="../../../src/xml/enriched-namespaces.xsl">
+    
+    <x:scenario label="Scenario testing completeness of the generated enriched namespaces">
+        <x:context href="../../ePO-default-config/namespaces.xml" select="/"/>
+        <x:variable name="userNamespacesCnt" as="xs:integer"
+            href="../../ePO-default-config/namespaces.xml" 
+            select="fn:count(//*:prefixes/*:prefix)"/>
+        <x:expect label="there is 1 top-level prefix element" test="count(*:prefixes) = 1"/>
+        <x:expect label="there are user-defined namespaces" 
+            test="fn:count(*:prefixes/*:prefix) >= $userNamespacesCnt"/>
+        <x:expect label="there is an internal namespace" 
+            test="*:prefixes/*:prefix[@name = 'core-shape'] = 'http://data.europa.eu/a4g/data-shape#'"/> 
+    </x:scenario>
+</x:description>

--- a/test/unitTests/test-xml/test-enriched-namespaces.xspec
+++ b/test/unitTests/test-xml/test-enriched-namespaces.xspec
@@ -4,6 +4,11 @@
     xmlns:xs="http://www.w3.org/2001/XMLSchema"
     stylesheet="../../../src/xml/enriched-namespaces.xsl">
     
+    <!-- Passing truthy value to avoid raising an error due to missing parameter
+    value. It's safe as the test doesn't use a file associated with the variable
+    anyway. -->
+    <x:param name="enrichedNamespacesPath" select="true()"/>
+
     <x:scenario label="Scenario testing completeness of the generated enriched namespaces">
         <x:context href="../../ePO-default-config/namespaces.xml" select="/"/>
         <x:variable name="userNamespacesCnt" as="xs:integer"
@@ -13,6 +18,6 @@
         <x:expect label="there are user-defined namespaces" 
             test="fn:count(*:prefixes/*:prefix) >= $userNamespacesCnt"/>
         <x:expect label="there is an internal namespace" 
-            test="*:prefixes/*:prefix[@name = 'core-shape'] = 'http://data.europa.eu/a4g/data-shape#'"/> 
+            test="*:prefixes/*:prefix[@name = 'core-shape']/@value = 'http://data.europa.eu/a4g/data-shape#'"/> 
     </x:scenario>
 </x:description>


### PR DESCRIPTION
`rdfpipe` utility is now used to regenerate *.rdf files what results in the duplicated imports being discarded. Changes were made in Makefile file and affects generation of *.rdf artefacts (owl-core, owl-restrictions and shacl Makefile recipes) as well as conversion of these to TTL format (convert-rdf-to-turtle). The latter were needed to keep the same TTL output when using the new *.rdf files.

Scope of the changes:
* New generic convert-between-serialization-formats Makefile recipe
* The existing owl-core, owl-restrictions and shacl Makefile recipes now include an RDF regeneration step
* The existing convert-rdf-to-turtle Makefile recipe now uses the same namespaces that are used for XSLT transformation (test/ePO-default-config/namespaces.xml) to provide rdfpipe with prefixes so the output makes use of compact URIs.
* As the reported issue occurs for EPO v4.2.0 which introduces some new prefixes, these prefixes have also been added to test/ePO-default-config/namespaces.xml so it would be possible to reproduce the fix.

The change fixes #213 