### PR TITLE
Accept alternative URIs of the supported UML versions

### DIFF
--- a/src/html-conventions-report.xsl
+++ b/src/html-conventions-report.xsl
@@ -42,7 +42,7 @@
             <xsl:call-template name="head"/>
             <xsl:choose>
                 <xsl:when
-                    test="fn:namespace-uri(//*:Model) = 'http://www.omg.org/spec/UML/20131001' and
+                    test="fn:namespace-uri(//*:Model) = $supportedUmlVersions and
                     fn:namespace-uri(//*:XMI) = 'http://www.omg.org/spec/XMI/20131001'">
                     <body>
                         <xsl:call-template name="title-header"/>
@@ -92,11 +92,11 @@
                         <i class="fa fa-times-circle error" style="font-size: 60px;"/>
                         <h1 class="counter-skip">Wrong model version detected. </h1>
                         <br/>
-                            <p>Please make sure that the XMI file uses XMI version 2.5.1 and UML version 2.5.1.</p> 
+                            <p>Please make sure that the XMI file uses XMI version 2.5.1 and UML version 2.5.x (either 2.5 or 2.5.1).</p> 
                         <p>The namespaces to check:</p>
                         <ul>
                             <li>xmi="http://www.omg.org/spec/XMI/20131001"</li>
-                            <li>uml="http://www.omg.org/spec/UML/20131001"</li>
+                            <li>uml="<xsl:sequence select='fn:string-join($supportedUmlVersions, " | ")'/>"</li>
                         </ul>
                     </div>
                 </xsl:otherwise>

--- a/src/html-model-glossary.xsl
+++ b/src/html-model-glossary.xsl
@@ -26,7 +26,7 @@
             <xsl:call-template name="head"/>
             <xsl:choose>
                 <xsl:when
-                    test="fn:namespace-uri(//*:Model) = 'http://www.omg.org/spec/UML/20131001' and
+                    test="fn:namespace-uri(//*:Model) = $supportedUmlVersions and
                     fn:namespace-uri(//*:XMI) = 'http://www.omg.org/spec/XMI/20131001'">
                     <body>
                         <main class="container-fluid">
@@ -49,11 +49,11 @@
                         <i class="fa fa-times-circle error" style="font-size: 60px;"/>
                         <h1 class="counter-skip">Wrong model version detected. </h1>
                         <br/>
-                        <p>Please make sure that the XMI file uses XMI version 2.5.1 and UML version 2.5.1.</p> 
+                        <p>Please make sure that the XMI file uses XMI version 2.5.1 and UML version 2.5.x (either 2.5 or 2.5.1).</p> 
                         <p>The namespaces to check:</p>
                         <ul>
                             <li>xmi="http://www.omg.org/spec/XMI/20131001"</li>
-                            <li>uml="http://www.omg.org/spec/UML/20131001"</li>
+                            <li>uml="<xsl:sequence select='fn:string-join($supportedUmlVersions, " | ")'/>'"</li>
                         </ul>
                     </div>
                 </xsl:otherwise>

--- a/src/svrl-conventions-report.xsl
+++ b/src/svrl-conventions-report.xsl
@@ -37,7 +37,7 @@
 
             <xsl:choose>
                 <xsl:when
-                    test="fn:namespace-uri(//*:Model) = 'http://www.omg.org/spec/UML/20131001' and
+                    test="fn:namespace-uri(//*:Model) = $supportedUmlVersions and
                     fn:namespace-uri(//*:XMI) = 'http://www.omg.org/spec/XMI/20131001'">
             
                     <xsl:apply-templates/>
@@ -47,9 +47,9 @@
                 </xsl:when>
                 <xsl:otherwise>
                     <svrl:fired-rule context="/" />
-                    <svrl:failed-assert test="/*/namespace::xmi = http://www.omg.org/spec/XMI/20131001 and /*/namespace::uml = http://www.omg.org/spec/UML/20131001">
-                        <svrl:text>Wrong model version detected.Please make sure that the XMI file uses XMI version 2.5.1 and UML version 2.5.1.
-                            The namespaces to check: uml="http://www.omg.org/spec/UML/20131001" and xmi="http://www.omg.org/spec/XMI/20131001"</svrl:text>
+                    <svrl:failed-assert test="/*/namespace::xmi = http://www.omg.org/spec/XMI/20131001 and /*/namespace::uml = $supportedUmlVersions">
+                        <svrl:text>Wrong model version detected.Please make sure that the XMI file uses XMI version 2.5.1 and UML version 2.5.x (either 2.5 or 2.5.1).
+                            The namespaces to check: uml="<xsl:sequence select='fn:string-join($supportedUmlVersions, " | ")'/>" and xmi="http://www.omg.org/spec/XMI/20131001"</svrl:text>
                     </svrl:failed-assert>
                 </xsl:otherwise>
             </xsl:choose>

--- a/test/ePO-default-config/config-parameters.xsl
+++ b/test/ePO-default-config/config-parameters.xsl
@@ -91,7 +91,14 @@
     <xsl:variable name="conventionReportAuthorLocation" select="'Luxembourg'"/>
     <xsl:variable name="conventionReportAuthorWebsite" select="'https://op.europa.eu'"/>
     <xsl:variable name="conventionReportUMLModelName" select="'eProcurement'"/>
-    
+    <!-- URIs list of UML versions supported by model2owl -->
+    <xsl:variable name="supportedUmlVersions"
+        select="('http://www.omg.org/spec/UML/20131001',
+            'https://www.omg.org/spec/UML/20131001',
+            'http://www.omg.org/spec/UML/20161101',
+            'https://www.omg.org/spec/UML/20161101'
+        )"/>
+
     <!-- _______________________________________________________________________   -->
     <!--                            METADATA SECTION                               -->
     <!-- _______________________________________________________________________   -->


### PR DESCRIPTION
Support for 2.5.x versions of the UML standard:

* v2.5: `http://www.omg.org/spec/UML/20131001` and `https://www.omg.org/spec/UML/20131001`

* v2.5.1: `http://www.omg.org/spec/UML/20161101` and `https://www.omg.org/spec/UML/20161101`