### PR TITLE
Improve camelCase into words functionality in model2owl

### DIFF
--- a/src/common/utils.xsl
+++ b/src/common/utils.xsl
@@ -236,8 +236,10 @@
     </xd:doc>
     <xsl:function name="f:lexicalQNameToWords" as="xs:string">
         <xsl:param name="lexicalqName" as="xs:string"/>
+        <xsl:variable name="localName"
+            select="fn:local-name-from-QName(f:buildQNameFromLexicalQName($lexicalqName))"/>
         <xsl:sequence 
-            select="fn:string-join(f:getSegmentsFromCamelCaseText($lexicalqName), ' ')" />
+            select="fn:string-join(f:getSegmentsFromCamelCaseText($localName), ' ')" />
     </xsl:function>
 
     <xd:doc>

--- a/src/common/utils.xsl
+++ b/src/common/utils.xsl
@@ -227,25 +227,138 @@
     </xsl:function>
 
 
-
-
-    <xd:doc>
-        <xd:desc>Turns the local segment of a lexicalised qName into words</xd:desc>
+     <xd:doc>
+        <xd:desc>
+            Turns the local segment of a lexicalised qName into words, handling
+            acronyms and camel case properly.
+        </xd:desc>
         <xd:param name="lexicalqName"/>
     </xd:doc>
     <xsl:function name="f:lexicalQNameToWords" as="xs:string">
         <xsl:param name="lexicalqName" as="xs:string"/>
+        <xsl:sequence 
+            select="fn:string-join(f:getSegmentsFromCamelCaseText($lexicalqName), ' ')" />
+    </xsl:function>
 
-        <xsl:sequence
-            select="
-                functx:capitalize-first(
-                fn:lower-case(
-                functx:camel-case-to-words(
-                fn:local-name-from-QName(
-                f:buildQNameFromLexicalQName($lexicalqName)
-                ), ' ')
-                ))"
+    <xd:doc>
+        <xd:desc>
+            Splits a camelCase name into a text. Supports acronyms.
+        </xd:desc>
+        <xd:param name="text"/>
+    </xd:doc>
+    <!-- The underlying function works on a reversed text as this makes
+    identification of the segments easier. -->
+    <xsl:function name="f:getSegmentsFromCamelCaseText" as="xs:string*">
+        <xsl:param name="text" as="xs:string"/>
+        <xsl:sequence 
+            select="for $segment in f:_getSegmentsRec(functx:reverse-string($text))
+            return functx:reverse-string($segment)" />
+    </xsl:function>
+
+    <xd:doc>
+        <xd:desc>
+            Splits a camelCase name into a text. Supports acronyms. Returns
+            sequence of found text segments (words and acronyms).
+        </xd:desc>
+        <xd:param name="text"/>
+    </xd:doc>
+    <!-- 
+    This is private, recursive function.
+    The function preserves case of split words. For example:
+    'hasLongName' => 'has Long Name' (not 'has long name').
+    -->
+    <xsl:function name="f:_getSegmentsRec" as="xs:string*">
+        <xsl:param name="text" as="xs:string"/>
+        <xsl:variable name="textLen" select="fn:string-length($text)"/>
+        <xsl:variable name="currSegment" select="f:_getLeftSubstrByCaseChange($text)"/>
+        <xsl:variable name="currSegmentLen" select="fn:string-length($currSegment)"/>
+        <xsl:variable name="nextSegmentOffset"
+            select="if (xs:integer($currSegmentLen) &lt; xs:integer($textLen))
+                then $currSegmentLen + 1 else ()"/>
+        <xsl:choose>
+            <xsl:when test="fn:boolean($nextSegmentOffset) = fn:true()">
+                <xsl:value-of select="(
+                    $currSegment, 
+                    f:_getSegmentsRec(fn:substring($text, $nextSegmentOffset))
+                )"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:value-of select="($currSegment)"/>  
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:function>
+
+    <xd:doc>
+        <xd:desc>
+            Detects a left substring based on a letter case change. Supports
+            acronyms.
+        </xd:desc>
+        <xd:param name="text"/>
+        <xd:param name="index"/>
+    </xd:doc>
+    <xsl:function name="f:_getLeftSubstrByCaseChange" as="xs:string">
+        <xsl:param name="text" as="xs:string"/>
+        <xsl:sequence select="f:_getLeftSubstrByCaseChangeRec($text, 1)"/>
+    </xsl:function>
+
+    <xd:doc>
+        <xd:desc>
+            Detects a left substring based on a letter case change. Supports
+            acronyms.
+        </xd:desc>
+        <xd:param name="text"/>
+        <xd:param name="index"/>
+    </xd:doc>
+    <!-- 
+    This is a private, recursive function. 
+    It's the basis for splitting camelCaseName into segments.
+    The function returns such a left substring which letters (except for the
+    ending*) has the same letter case as the first letter.
+    Ending of the returned substring varies depending on the letter case transition:
+    1) lower to upper: INCLUDE the last character with a diffferent case.
+    2) upper to lower: EXCLUDE the last character with a diffferent case.
+    -->
+    <xsl:function name="f:_getLeftSubstrByCaseChangeRec" as="xs:string">
+        <xsl:param name="text" as="xs:string"/>
+        <xsl:param name="index" as="xs:integer"/>
+        <xsl:variable name="firstChar" select="fn:substring($text, 1, 1)"/>
+        <xsl:variable name="textLen" select="fn:string-length($text)"/>
+        <xsl:sequence select="
+        if (f:haveSameCase(fn:substring($text, $index, 1), $firstChar))
+        then 
+            if (xs:integer($index) &lt; xs:integer($textLen))
+            then f:_getLeftSubstrByCaseChangeRec($text, $index + 1) 
+            else $text
+        else 
+            if(f:isUpperCase($firstChar))
+            then fn:substring($text, 1, $index - 1)
+            else fn:substring($text, 1, $index)" 
         />
+    </xsl:function>
+
+    <xd:doc>
+        <xd:desc>
+            Checks if a character is uppercase.
+        </xd:desc>
+        <xd:param name="char"/>
+    </xd:doc>
+    <xsl:function name="f:isUpperCase" as="xs:boolean">
+        <xsl:param name="char" as="xs:string"/>
+        <xsl:sequence select="matches($char, '[A-Z]')"/>
+    </xsl:function>
+
+    <xd:doc>
+        <xd:desc>
+            Checks if the two passed character have the same letter case
+            (either lower case or upper case).
+        </xd:desc>
+        <xd:param name="char1"/>
+        <xd:param name="char2"/>
+    </xd:doc>
+    <xsl:function name="f:haveSameCase" as="xs:boolean">
+        <xsl:param name="char1" as="xs:string"/>
+        <xsl:param name="char2" as="xs:string"/>
+        <xsl:sequence select="f:isUpperCase($char1) = f:isUpperCase($char2)"/>
     </xsl:function>
 
     <xd:doc>

--- a/test/unitTests/test-common/test-camelcase.xspec
+++ b/test/unitTests/test-common/test-camelcase.xspec
@@ -11,10 +11,108 @@
     stylesheet="../../../src/common/utils.xsl">
     
     <x:scenario label="QName to words">
-        <x:call function="f:lexicalQNameToWords">
-            <x:param name="input">hasEPORoleType</x:param>
-        </x:call>
-        <x:expect label="Transformation from Qname to words is valid" select="'Has e p o role type'"/>
+        <x:scenario label="QName to words 1">
+            <x:call function="f:lexicalQNameToWords">
+                <x:param name="lexicalqName">hasEPORole</x:param>
+            </x:call>
+            <x:expect label="Transformation from Qname to words is valid" select="'has EPO Role'"/>
+        </x:scenario>
+        <x:scenario label="QName to words 2">
+            <x:call function="f:lexicalQNameToWords">
+                <x:param name="lexicalqName">hasVehicleID</x:param>
+            </x:call>
+            <x:expect label="Transformation from Qname to words is valid" select="'has Vehicle ID'"/>
+        </x:scenario>
+        <x:scenario label="QName to words 3">
+            <x:call function="f:lexicalQNameToWords">
+                <x:param name="lexicalqName">hasUUID</x:param>
+            </x:call>
+            <x:expect label="Transformation from Qname to words is valid" select="'has UUID'"/>
+        </x:scenario>
+        <x:scenario label="QName to words 4">
+            <x:call function="f:lexicalQNameToWords">
+                <x:param name="lexicalqName">ESPD</x:param>
+            </x:call>
+            <x:expect label="Transformation from Qname to words is valid" select="'ESPD'"/>
+        </x:scenario>
+        <x:scenario label="QName to words 5">
+            <x:call function="f:lexicalQNameToWords">
+                <x:param name="lexicalqName">ESPDDocument</x:param>
+            </x:call>
+            <x:expect label="Transformation from Qname to words is valid" select="'ESPD Document'"/>
+        </x:scenario>
+        <x:scenario label="QName to words 6">
+            <x:call function="f:lexicalQNameToWords">
+                <x:param name="lexicalqName">hasLongName</x:param>
+            </x:call>
+            <x:expect label="Transformation from Qname to words is valid" select="'has Long Name'"/>
+        </x:scenario>
+    </x:scenario>
+    
+    <x:scenario label="_getSegmentsRec">
+        <x:scenario label="_getSegmentsRec 1">
+            <x:call function="f:_getSegmentsRec">
+                <x:param name="text">DPSE</x:param>
+            </x:call>
+            <x:expect label="Transformation from Qname to words is valid" select="'DPSE'"/>
+        </x:scenario>
+        <x:scenario label="_getSegmentsRec 2">
+            <x:call function="f:_getSegmentsRec">
+                <x:param name="text">sah</x:param>
+            </x:call>
+            <x:expect label="Transformation from Qname to words is valid" select="'sah'"/>
+        </x:scenario>
+        <x:scenario label="_getSegmentsRec 3">
+            <x:call function="f:_getSegmentsRec">
+                <x:param name="text">OPEsah</x:param>
+            </x:call>
+            <x:expect label="Transformation from Qname to words is valid" select="'OPE sah'"/>
+        </x:scenario>
+        <x:scenario label="_getSegmentsRec 4">
+            <x:call function="f:_getSegmentsRec">
+                <x:param name="text">eloROPEsah</x:param>
+            </x:call>
+            <x:expect label="Transformation from Qname to words is valid" select="'eloR OPE sah'"/>
+        </x:scenario>
+        <x:scenario label="_getSegmentsRec 5">
+            <x:call function="f:_getSegmentsRec">
+                <x:param name="text">DIUUsah</x:param>
+            </x:call>
+            <x:expect label="Transformation from Qname to words is valid" select="'DIUU sah'"/>
+        </x:scenario>
+        <x:scenario label="_getSegmentsRec 6">
+            <x:call function="f:_getSegmentsRec">
+                <x:param name="text">tnemucoDDPSE</x:param>
+            </x:call>
+            <x:expect label="Transformation from Qname to words is valid" select="'tnemucoD DPSE'"/>
+        </x:scenario>
+    </x:scenario>
+
+    <x:scenario label="getLeftSubstrByCaseChange">
+        <x:scenario label="getLeftSubstrByCaseChange 1">
+            <x:call function="f:_getLeftSubstrByCaseChange">
+                <x:param name="text">eloROPEsah</x:param>
+            </x:call>
+            <x:expect label="Transformation from Qname to words is valid" select="'eloR'"/>
+        </x:scenario>
+        <x:scenario label="getLeftSubstrByCaseChange 2">
+            <x:call function="f:_getLeftSubstrByCaseChange">
+                <x:param name="text">OPEsah</x:param>
+            </x:call>
+            <x:expect label="Transformation from Qname to words is valid" select="'OPE'"/>
+        </x:scenario>
+        <x:scenario label="getLeftSubstrByCaseChange 3">
+            <x:call function="f:_getLeftSubstrByCaseChange">
+                <x:param name="text">sah</x:param>
+            </x:call>
+            <x:expect label="Transformation from Qname to words is valid" select="'sah'"/>
+        </x:scenario> 
+        <x:scenario label="getLeftSubstrByCaseChange 4">
+            <x:call function="f:_getLeftSubstrByCaseChange">
+                <x:param name="text">DPSE</x:param>
+            </x:call>
+            <x:expect label="Transformation from Qname to words is valid" select="'DPSE'"/>
+        </x:scenario>
     </x:scenario>
     
 </x:description>

--- a/test/unitTests/test-common/test-utils.xspec
+++ b/test/unitTests/test-common/test-utils.xspec
@@ -209,7 +209,7 @@
         <x:call function="f:lexicalQNameToWords">
             <x:param name="lexicalqName">xsd:longInteger</x:param> 
         </x:call>
-        <x:expect label="result" select="string('Long Integer')"/>
+        <x:expect label="result" select="string('long Integer')"/>
     </x:scenario>
     
     

--- a/test/unitTests/test-common/test-utils.xspec
+++ b/test/unitTests/test-common/test-utils.xspec
@@ -209,7 +209,7 @@
         <x:call function="f:lexicalQNameToWords">
             <x:param name="lexicalqName">xsd:longInteger</x:param> 
         </x:call>
-        <x:expect label="result" select="string('Long integer')"/>
+        <x:expect label="result" select="string('Long Integer')"/>
     </x:scenario>
     
     

--- a/test/unitTests/test-owl-core-lib/test-connectors-owl-core.xspec
+++ b/test/unitTests/test-owl-core-lib/test-connectors-owl-core.xspec
@@ -173,7 +173,7 @@
     
         <x:expect label="has only one owl:ObjectProperty defined" test="count(/owl:ObjectProperty) = 1"/>
         <x:expect label="is owl:ObjectProperty defined" test="/owl:ObjectProperty/@rdf:about=$testedPropUri"/>
-        <x:expect label="correct skos:prefLabel" test="/rdf:Description[@rdf:about = $testedPropUri]/skos:prefLabel[@xml:lang='en']/text() = 'Comprises lot award outcome'"/>
+        <x:expect label="correct skos:prefLabel" test="/rdf:Description[@rdf:about = $testedPropUri]/skos:prefLabel[@xml:lang='en']/text() = 'comprises Lot Award Outcome'"/>
         <x:expect label="has skos:definition" test="boolean(/rdf:Description[@rdf:about=$testedPropUri]/skos:definition[@xml:lang='en'])"/>
         <x:expect label="is linked to the ontology" test="/rdf:Description[@rdf:about = $testedPropUri]/rdfs:isDefinedBy/@rdf:resource = 'http://data.europa.eu/a4g/ontology#core'"/>
     </x:scenario>

--- a/test/unitTests/test-owl-core-lib/test-descriptors-owl-core.xspec
+++ b/test/unitTests/test-owl-core-lib/test-descriptors-owl-core.xspec
@@ -22,7 +22,7 @@
             <x:expect label="there is rdf:Description"
                 test="boolean(/rdf:Description[@rdf:about='http:/fake.uri#something'])"
             />
-        <x:expect label="correct label" test="rdf:Description/skos:prefLabel/text() = 'Dynamic procedure'"/>
+        <x:expect label="correct label" test="rdf:Description/skos:prefLabel/text() = 'Dynamic Procedure'"/>
             
         
     </x:scenario>

--- a/test/unitTests/test-owl-core-lib/test-elements-owl-core_with-concept-schemes.xspec
+++ b/test/unitTests/test-owl-core-lib/test-elements-owl-core_with-concept-schemes.xspec
@@ -21,7 +21,7 @@
         <x:variable name="testedEnum" as="xs:string" select="'http://www.w3.org/2006/time#TemporalUnit'"/>
         
         <x:expect label="there is a skos:ConceptScheme" test="/skos:ConceptScheme/@rdf:about = $testedEnum"/>
-        <x:expect label="there is a skos:prefLabel" test="/rdf:Description[@rdf:about = $testedEnum]/skos:prefLabel[@xml:lang='en']/text() = 'Temporal unit'"/>
+        <x:expect label="there is a skos:prefLabel" test="/rdf:Description[@rdf:about = $testedEnum]/skos:prefLabel[@xml:lang='en']/text() = 'Temporal Unit'"/>
     </x:scenario>
 
 </x:description>

--- a/test/unitTests/test-shacl-shape-lib/test-descriptors-shacl-shape.xspec
+++ b/test/unitTests/test-shacl-shape-lib/test-descriptors-shacl-shape.xspec
@@ -24,7 +24,7 @@
         <x:expect label="there is rdf:Description"
             test="boolean(/rdf:Description[@rdf:about='http:/fake.uri#something'])"
         />
-        <x:expect label="correct label" test="rdf:Description/rdfs:label/text() = 'Dynamic procedure'"/>
+        <x:expect label="correct label" test="rdf:Description/rdfs:label/text() = 'Dynamic Procedure'"/>
         
         
     </x:scenario>
@@ -40,7 +40,7 @@
         <x:expect label="there is rdf:Description"
             test="boolean(/rdf:Description[@rdf:about='http:/fake.uri#something'])"
         />
-        <x:expect label="correct label" test="rdf:Description/sh:name/text() = 'Dynamic procedure'"/>
+        <x:expect label="correct label" test="rdf:Description/sh:name/text() = 'Dynamic Procedure'"/>
         
         
     </x:scenario>

--- a/test/unitTests/test-shacl-shape-lib/test-elements-shacl-shape.xspec
+++ b/test/unitTests/test-shacl-shape-lib/test-elements-shacl-shape.xspec
@@ -122,7 +122,7 @@
             as="xs:string"
             select="'http://data.europa.eu/a4g/data-shape#epo-FrameworkAgreementTerm-epo-hasMaximumParticipantsNumber'"/>
         <x:expect label="correct node-property shapes link" test="boolean(/rdf:Description[@rdf:about='http://data.europa.eu/a4g/data-shape#epo-FrameworkAgreementTerm']/sh:property[@rdf:resource=$testedPropShapeUri])"/>
-        <x:expect label="property shape: correct name" test="/rdf:Description[@rdf:about=$testedPropShapeUri]/sh:name/text() = 'Has maximum participants number'"/>
+        <x:expect label="property shape: correct name" test="/rdf:Description[@rdf:about=$testedPropShapeUri]/sh:name/text() = 'has Maximum Participants Number'"/>
         <x:expect label="property shape: correct datatype" test="boolean(/rdf:Description[@rdf:about=$testedPropShapeUri]/sh:datatype[@rdf:resource='http://www.w3.org/2001/XMLSchema#integer'])"/>
         <x:expect label="property shape: correct maxCount" test="/rdf:Description[@rdf:about=$testedPropShapeUri]/sh:maxCount = 1"/>
         <x:expect label="property shape: correct description" test="boolean(/rdf:Description[@rdf:about=$testedPropShapeUri]/sh:description)"/>


### PR DESCRIPTION
`f:lexicalQNameToWords` function has been reimplemented to support camelCase names containing acronyms.
The following examples demonstrates output of the functions for some cases:
* hasEPORole → has EPO Role
* hasSomethingElse → has Something Else
* hasVehicleID → has Vehicle ID
* hasUUID → has UUID
* ESPD → ESPD

Scope of changes:
1. new implementation of the `f:lexicalQNameToWords` along with auxiliary private functions
2. unit tests has been implemented
3. existing unit tests has been updated