### PR TITLE
Update config parameter name and its description

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,8 +164,8 @@ variables**
 The following variables determine the inclusion or exclusion of reused concepts within each artifact:
 ```shell
 
-<!-- This variable stores the concept prefixes that should be excluded from being treated as external or reused.-->
-<xsl:variable name="internalModelPrefixesList" select="('epo', 'epo-not', 'epo-ord', 'epo-cat', 'epo-con', 'epo-ful')"/>
+<!-- This variable stores the concept prefixes that should be excluded from being treated as external or reused. Concepts with these prefixes will be included in the generated artefacts. -->
+<xsl:variable name="includedPrefixesList" select="('epo', 'epo-not', 'epo-ord', 'epo-cat', 'epo-con', 'epo-ful')"/>
 
 <!-- Controls whether reused concepts are generated in SHACL artefact -->
 <xsl:variable name="generateReusedConceptsSHACL" select="fn:true()"/>
@@ -182,7 +182,7 @@ The following variables determine the inclusion or exclusion of reused concepts 
 
 Explanation
 
-* internalModelPrefixesList: Concepts with the specified prefixes in this list will be treated as internal to the model and will not be excluded from the artefacts, regardless of the settings for generating reused concepts controls (see below).
+* includedPrefixesList: Concepts with the specified prefixes in this list will be treated as internal to the model and will not be excluded from the artefacts, regardless of the settings for generating reused concepts controls (see below).
 * generateReusedConceptsSHACL: Set to true, reused concepts will be included in SHACL artefact.
 * generateReusedConceptsOWLcore: Set to false, reused concepts will be excluded from OWL core artefact.
 * generateReusedConceptsOWLrestrictions: Set to false, reused concepts will be excluded from OWL restrictions artefact.

--- a/docs/config-files/config-parameters.md
+++ b/docs/config-files/config-parameters.md
@@ -89,9 +89,9 @@ This document provides an explanation for the variables in the configuration fil
 - **Type:** String (Regex Pattern)
 - **Description:** Defines valid characters for a normalised string.
 
-### 18. `internalModelPrefixesList`
+### 18. `includedPrefixesList`
 - **Type:** List
-- **Description:** Specifies prefixes that should be considered internal to the model and not reused.
+- **Description:** Specifies prefixes that should be considered internal to the model and not reused. The variable controls what concepts will be *included* in the generated artefacts when generation of reused concepts is disabled. 
 
 ### 19. Filter reused concepts variables
 - **Type:** Boolean

--- a/src/html-model-glossary/glossary.xsl
+++ b/src/html-model-glossary/glossary.xsl
@@ -71,7 +71,7 @@
         <xsl:variable name="classNames" select="f:getDistinctClassNames($root)"/>
         <xsl:for-each select="$classNames">
             <xsl:sort select="." lang="en"/>
-            <xsl:if test="$generateReusedConceptsGlossary or fn:substring-before(., ':') = $internalModelPrefixesList">
+            <xsl:if test="$generateReusedConceptsGlossary or fn:substring-before(., ':') = $includedPrefixesList">
                 <tr>
                     <td>
                         <xsl:value-of select="."/>
@@ -96,7 +96,7 @@
         <xsl:for-each select="$attributeNames">
             <xsl:sort select="." lang="en"/>
             <xsl:variable name="attributeName" select="."/>
-            <xsl:if test="$generateReusedConceptsGlossary or fn:substring-before($attributeName, ':') = $internalModelPrefixesList">
+            <xsl:if test="$generateReusedConceptsGlossary or fn:substring-before($attributeName, ':') = $includedPrefixesList">
             <tr>
                 <xsl:call-template name="classAttributeUsage">
                     <xsl:with-param name="attributeName" select="$attributeName"/>
@@ -183,7 +183,7 @@
         <xsl:variable name="connectorNames" select="f:getDistinctConnectorsNames($root)"/>
         <xsl:for-each select="$connectorNames">
             <xsl:sort select="." lang="en"/>
-            <xsl:if test="$generateReusedConceptsGlossary or fn:substring-before(., ':') = $internalModelPrefixesList">
+            <xsl:if test="$generateReusedConceptsGlossary or fn:substring-before(., ':') = $includedPrefixesList">
                 <xsl:variable name="connectorName" select="."/>
                 <tr>
                     <td>
@@ -221,7 +221,7 @@
                                 if (f:getElementByIdRef(./target/@xmi:idref, $root)/@name) then
                                     f:getElementByIdRef(./target/@xmi:idref, $root)/@name
                                 else
-                                if (fn:substring-before(./target/model/@name, ':') = $internalModelPrefixesList) then
+                                if (fn:substring-before(./target/model/@name, ':') = $includedPrefixesList) then
                                         ./target/model/@name
                                     else
                                     if ($generateReusedConceptsGlossary) then
@@ -234,7 +234,7 @@
                                 if (f:getElementByIdRef(./source/@xmi:idref, $root)/@name) then
                                     f:getElementByIdRef(./source/@xmi:idref, $root)/@name
                                 else
-                                if (fn:substring-before(./source/model/@name, ':') = $internalModelPrefixesList) then
+                                if (fn:substring-before(./source/model/@name, ':') = $includedPrefixesList) then
                                         ./source/model/@name
                                     else
                                     if ($generateReusedConceptsGlossary) then
@@ -278,7 +278,7 @@
                         if (f:getElementByIdRef($connectorsWithSameName/target/@xmi:idref, $root)/@name) then
                             f:getElementByIdRef($connectorsWithSameName/target/@xmi:idref, $root)/@name
                         else
-                        if (fn:substring-before($connectorsWithSameName/target/model/@name, ':') = $internalModelPrefixesList) then
+                        if (fn:substring-before($connectorsWithSameName/target/model/@name, ':') = $includedPrefixesList) then
                         $connectorsWithSameName/target/model/@name
                             else
                                 if ($generateReusedConceptsGlossary) then
@@ -291,7 +291,7 @@
                         if (f:getElementByIdRef($connectorsWithSameName/source/@xmi:idref, $root)/@name) then
                             f:getElementByIdRef($connectorsWithSameName/source/@xmi:idref, $root)/@name
                         else
-                        if (fn:substring-before($connectorsWithSameName/source/model/@name, ':') = $internalModelPrefixesList) then
+                        if (fn:substring-before($connectorsWithSameName/source/model/@name, ':') = $includedPrefixesList) then
                         $connectorsWithSameName/source/model/@name
                             else
                                 if ($generateReusedConceptsGlossary) then

--- a/src/owl-core-lib/connectors-owl-core.xsl
+++ b/src/owl-core-lib/connectors-owl-core.xsl
@@ -49,9 +49,9 @@
             <xsl:variable name="targetPrefix"
                 select="fn:substring-before(./target/model/@name, ':')"/>
 
-            <!-- Check if either the prefixes match the internal list or generateReusedConcepts is true -->
+            <!-- Check if either the prefixes match the internal prefixes list (prefixes to be included) or generateReusedConcepts is true -->
             <xsl:if
-                test="$generateReusedConceptsOWLcore or ($sourcePrefix = $internalModelPrefixesList or $targetPrefix = $internalModelPrefixesList)">
+                test="$generateReusedConceptsOWLcore or ($sourcePrefix = $includedPrefixesList or $targetPrefix = $includedPrefixesList)">
                 <xsl:call-template name="classRealisation">
                     <xsl:with-param name="realisation" select="."/>
                 </xsl:call-template>
@@ -142,7 +142,7 @@
                     select="fn:substring-before($targetConnectorTargetName, ':')"/>
                 <!-- Check if either the prefixes match the internal list or generateReusedConcepts is true -->
                 <xsl:if
-                    test="$generateReusedConceptsOWLcore or $sourceConnectorTargetNamePrefix = $internalModelPrefixesList">
+                    test="$generateReusedConceptsOWLcore or $sourceConnectorTargetNamePrefix = $includedPrefixesList">
                     <owl:ObjectProperty rdf:about="{$sourceConnectorTargetUri}">
                         <rdfs:subPropertyOf rdf:resource="{$targetConnectorTargetUri}"/>
                     </owl:ObjectProperty>
@@ -181,7 +181,7 @@
                     select="fn:substring-before($sourceConnectorSourceName, ':')"/>
                 <!-- Check if either the prefixes match the internal list or generateReusedConcepts is true -->
                 <xsl:if
-                    test="$generateReusedConceptsOWLcore or $sourceConnectorSourceNamePrefix = $internalModelPrefixesList">
+                    test="$generateReusedConceptsOWLcore or $sourceConnectorSourceNamePrefix = $includedPrefixesList">
 
                     <owl:ObjectProperty rdf:about="{$sourceConnectorSourceUri}">
                         <rdfs:subPropertyOf rdf:resource="{$targetConnectorSourceUri}"/>
@@ -206,7 +206,7 @@
                 <xsl:variable name="connectorElement" select="f:getConnectorByName(., $root)"/>
                 <xsl:variable name="connectorRoleName" select="f:getRoleNameFromConnector($connectorElement)"/>
                 <xsl:if
-                    test="$generateReusedConceptsOWLcore or fn:substring-before($connectorRoleName, ':') = $internalModelPrefixesList">
+                    test="$generateReusedConceptsOWLcore or fn:substring-before($connectorRoleName, ':') = $includedPrefixesList">
 
                     <xsl:call-template name="genericConnector">
                         <xsl:with-param name="connectorName" select="."/>
@@ -309,7 +309,7 @@
         <xsl:if test="f:getElementByIdRef(./source/@xmi:idref, root(.))">
 
             <xsl:for-each select="$subClasses">
-                <xsl:if test="$generateReusedConceptsOWLcore or fn:substring-before(./@name, ':') = $internalModelPrefixesList">
+                <xsl:if test="$generateReusedConceptsOWLcore or fn:substring-before(./@name, ':') = $includedPrefixesList">
                 <xsl:variable name="subClassURI" select="f:buildURIFromElement(.)"/>
                 <owl:Class rdf:about="{$subClassURI}">
                     <rdfs:subClassOf rdf:resource="{$superClassURI}"/>

--- a/src/owl-core-lib/elements-owl-core.xsl
+++ b/src/owl-core-lib/elements-owl-core.xsl
@@ -105,7 +105,7 @@
     <xsl:template match="element[@xmi:type = 'uml:Class']">
         <xsl:variable name="classPrefix" select="fn:substring-before(./@name, ':')"/>
         <!-- Check if the class should be processed -->
-        <xsl:if test="$generateReusedConceptsOWLcore or $classPrefix = $internalModelPrefixesList">
+        <xsl:if test="$generateReusedConceptsOWLcore or $classPrefix = $includedPrefixesList">
             <xsl:call-template name="classDeclaration"/>
         </xsl:if>
 
@@ -171,7 +171,7 @@
 
             <!-- Check if the attribute should be processed -->
             <xsl:if
-                test="$generateReusedConceptsOWLcore or $attributePrefix = $internalModelPrefixesList">
+                test="$generateReusedConceptsOWLcore or $attributePrefix = $includedPrefixesList">
                 <xsl:call-template name="generatePropertyFromAttribute">
                     <xsl:with-param name="attributeName" select="."/>
                     <xsl:with-param name="root" select="$root"/>
@@ -285,7 +285,7 @@
 
         <!-- Check if the DataType should be processed -->
         <xsl:if
-            test="$generateReusedConceptsOWLcore or $dataTypePrefix = $internalModelPrefixesList">
+            test="$generateReusedConceptsOWLcore or $dataTypePrefix = $includedPrefixesList">
             <xsl:choose>
                 <xsl:when test="not(attributes)">
                     <xsl:call-template name="datatypeDeclaration"/>
@@ -349,7 +349,7 @@
             <xsl:variable name="enumerationPrefix" select="fn:substring-before($conceptSchemeName, ':')"/>
             <!-- Check if the Enumeration should be processed -->
             <xsl:if
-                test="$generateReusedConceptsOWLcore or $enumerationPrefix = $internalModelPrefixesList">
+                test="$generateReusedConceptsOWLcore or $enumerationPrefix = $includedPrefixesList">
                 <xsl:variable name="conceptSchemeURI" select="f:buildURIFromElement(.)"/>
                 <xsl:variable name="documentation"
                     select="fn:normalize-space(f:formatDocString(./properties/@documentation))"/>
@@ -406,7 +406,7 @@
                 select="fn:substring-before($enumerationAttributeName, ':')"/>
             <!-- Check if the Enumeration should be processed -->
             <xsl:if
-                test="$generateReusedConceptsOWLcore or $enumerationAttributePrefix = $internalModelPrefixesList">
+                test="$generateReusedConceptsOWLcore or $enumerationAttributePrefix = $includedPrefixesList">
                 <xsl:variable name="enumerationAttributeURI" select="f:buildURIFromElement(.)"/>
                 <xsl:variable name="enumerationURI" select="f:buildURIFromElement(../..)"/>
                 <xsl:variable name="documentation"

--- a/src/reasoning-layer-lib/connectors-reasoning-layer.xsl
+++ b/src/reasoning-layer-lib/connectors-reasoning-layer.xsl
@@ -31,7 +31,7 @@
             test="
                 ./source/model/@type = 'Class' and ./target/model/@type = 'Class' and
                 ($generateReusedConceptsOWLrestrictions or
-                fn:substring-before($connectorRoleName, ':') = $internalModelPrefixesList)">
+                fn:substring-before($connectorRoleName, ':') = $includedPrefixesList)">
             <xsl:call-template name="connectorMultiplicity">
                 <xsl:with-param name="connector" select="."/>
             </xsl:call-template>
@@ -51,7 +51,7 @@
             test="
                 ./source/model/@type = 'Class' and ./target/model/@type = 'Class' and
                 ($generateReusedConceptsOWLrestrictions or
-                fn:substring-before($connectorRoleName, ':') = $internalModelPrefixesList)">
+                fn:substring-before($connectorRoleName, ':') = $includedPrefixesList)">
             <xsl:call-template name="connectorMultiplicity">
                 <xsl:with-param name="connector" select="."/>
             </xsl:call-template>
@@ -63,7 +63,7 @@
             test="
                 ./source/model/@type = 'Class' and ./target/model/@type = 'Enumeration' and
                 ($generateReusedConceptsOWLrestrictions or
-                fn:substring-before($connectorRoleName, ':') = $internalModelPrefixesList)">
+                fn:substring-before($connectorRoleName, ':') = $includedPrefixesList)">
             <xsl:call-template name="connectorDependencyRange">
                 <xsl:with-param name="connector" select="."/>
             </xsl:call-template>
@@ -102,7 +102,7 @@
                     select="fn:substring-before(./target/model/@name, ':')"/>
                 <!-- Check if either the prefixes match the internal list or generateReusedConcepts is true -->
                 <xsl:if
-                    test="$generateReusedConceptsOWLrestrictions or $sourcePrefix = $internalModelPrefixesList">
+                    test="$generateReusedConceptsOWLrestrictions or $sourcePrefix = $includedPrefixesList">
                     <xsl:call-template name="disjointClasses">
                         <xsl:with-param name="generalisation" select="."/>
                     </xsl:call-template>
@@ -128,7 +128,7 @@
                 <xsl:variable name="connectorElement" select="f:getConnectorByName(., $root)"/>
                 <xsl:variable name="connectorRoleName" select="f:getRoleNameFromConnector($connectorElement)"/>
                 <xsl:if
-                    test="$generateReusedConceptsOWLrestrictions or fn:substring-before($connectorRoleName, ':') = $internalModelPrefixesList">
+                    test="$generateReusedConceptsOWLrestrictions or fn:substring-before($connectorRoleName, ':') = $includedPrefixesList">
                     <xsl:call-template name="connectorDomain">
                         <xsl:with-param name="connectorName" select="."/>
                         <xsl:with-param name="root" select="$root"/>
@@ -402,7 +402,7 @@
             <xsl:if
                 test="
                     $generateReusedConceptsOWLrestrictions or
-                    $sourcePrefix = $internalModelPrefixesList">
+                    $sourcePrefix = $includedPrefixesList">
 
                 <rdf:Description rdf:about="{$sourceClassURI}">
                     <owl:equivalentClass rdf:resource="{$targetClassURI}"/>
@@ -454,7 +454,7 @@
             <xsl:if
                 test="
                     $generateReusedConceptsOWLrestrictions or
-                    fn:substring-before($sourceConnector/source/model/@name, ':') = $internalModelPrefixesList">
+                    fn:substring-before($sourceConnector/source/model/@name, ':') = $includedPrefixesList">
                 <rdf:Description rdf:about="{$sourceConnectorSourceRoleURI}">
                     <owl:equivalentProperty rdf:resource="{$targetConnectorSourceRoleURI}"/>
                 </rdf:Description>
@@ -462,7 +462,7 @@
             <xsl:if
                 test="
                     $generateReusedConceptsOWLrestrictions or
-                    fn:substring-before($targetConnector/source/model/@name, ':') = $internalModelPrefixesList">
+                    fn:substring-before($targetConnector/source/model/@name, ':') = $includedPrefixesList">
                 <rdf:Description rdf:about="{$sourceConnectorTargetRoleURI}">
                     <owl:equivalentProperty rdf:resource="{$targetConnectorTargetRoleURI}"/>
                 </rdf:Description>

--- a/src/reasoning-layer-lib/elements-reasoning-layer.xsl
+++ b/src/reasoning-layer-lib/elements-reasoning-layer.xsl
@@ -31,7 +31,7 @@
 
         <!-- Check if the attribute should be processed -->
         <xsl:if
-            test="$generateReusedConceptsOWLrestrictions or $attributePrefix = $internalModelPrefixesList">
+            test="$generateReusedConceptsOWLrestrictions or $attributePrefix = $includedPrefixesList">
             <xsl:call-template name="attributeMultiplicity">
                 <xsl:with-param name="attribute" select="."/>
             </xsl:call-template>
@@ -50,7 +50,7 @@
 
             <!-- Check if the attribute should be processed -->
             <xsl:if
-                test="$generateReusedConceptsOWLrestrictions or $attributePrefix = $internalModelPrefixesList">
+                test="$generateReusedConceptsOWLrestrictions or $attributePrefix = $includedPrefixesList">
                 <xsl:call-template name="attributeDomain">
                     <xsl:with-param name="attributeName" select="."/>
                     <xsl:with-param name="root" select="$root"/>
@@ -318,7 +318,7 @@
             <xsl:variable name="enumerationPrefix" select="fn:substring-before(./@name, ':')"/>
             <!-- Check if the Enumeration should be processed -->
             <xsl:if
-                test="$generateReusedConceptsOWLrestrictions or $enumerationPrefix = $internalModelPrefixesList">
+                test="$generateReusedConceptsOWLrestrictions or $enumerationPrefix = $includedPrefixesList">
                 <xsl:variable name="enumerationURI" select="f:buildURIFromElement(.)"/>
                 <owl:Class rdf:about="{$enumerationURI}">
                     <owl:equivalentClass>

--- a/src/shacl-shape-lib/connectors-shacl-shape.xsl
+++ b/src/shacl-shape-lib/connectors-shacl-shape.xsl
@@ -39,7 +39,7 @@
                 not(./source/model/@type = 'ProxyConnector' or ./target/model/@type = 'ProxyConnector') and (
                 $generateReusedConceptsSHACL = fn:true()
                 or
-                fn:substring-before($connectorRoleName, ':') = $internalModelPrefixesList)">
+                fn:substring-before($connectorRoleName, ':') = $includedPrefixesList)">
             <xsl:call-template name="connectorRange">
                 <xsl:with-param name="connector" select="."/>
             </xsl:call-template>
@@ -66,7 +66,7 @@
                 not(./source/model/@type = 'ProxyConnector' or ./target/model/@type = ('ProxyConnector', 'Object')) and (
                 $generateReusedConceptsSHACL = fn:true()
                 or
-                fn:substring-before($connectorRoleName, ':') = $internalModelPrefixesList)">
+                fn:substring-before($connectorRoleName, ':') = $includedPrefixesList)">
             <xsl:choose>
                 <xsl:when
                     test="not(./source/model/@type = 'Class' and ./target/model/@type = 'Enumeration')">

--- a/src/shacl-shape-lib/elements-shacl-shape.xsl
+++ b/src/shacl-shape-lib/elements-shacl-shape.xsl
@@ -113,7 +113,7 @@
             select="fn:normalize-space(f:formatDocString($class/properties/@documentation))"/>
         <!-- Check if the prefix is in the list or if generateReusedConceptsSHACL is true -->
         <xsl:if
-            test="$generateReusedConceptsSHACL = fn:true() or $classNamePrefix = $internalModelPrefixesList">
+            test="$generateReusedConceptsSHACL = fn:true() or $classNamePrefix = $includedPrefixesList">
             <sh:NodeShape rdf:about="{$shapeClassUri}">
                 <sh:targetClass rdf:resource="{$classURI}"/>
 
@@ -164,7 +164,7 @@
         <!--        generating only for attributes that don't have a coresponding relation (dependency)-->
         <xsl:if test="not($isAttributeWithDependencyName)">
             <xsl:if
-                test="$generateReusedConceptsSHACL = fn:true() or $attributePrefix = $internalModelPrefixesList">
+                test="$generateReusedConceptsSHACL = fn:true() or $attributePrefix = $includedPrefixesList">
                 <xsl:call-template name="classAttributeDeclaration">
                     <xsl:with-param name="attribute" select="."/>
                     <xsl:with-param name="className" select="$className"/>

--- a/test/ePO-default-config/config-parameters.xsl
+++ b/test/ePO-default-config/config-parameters.xsl
@@ -75,8 +75,8 @@
 
     <!--Allowed characters for a normalized string-->
     <xsl:variable name="allowedStrings" select="'^[\w\d-_:]+$'"/>
-    <!--    Generate reused classes, attributes and connectors-->
-    <xsl:variable name="internalModelPrefixesList" select="('epo', 'epo-not', 'epo-ord', 'epo-cat', 'epo-con', 'epo-ful')"/>
+    <!--    Generate reused classes, attributes and connectors. Concepts with these prefixes will be included in the generated artefacts. -->
+    <xsl:variable name="includedPrefixesList" select="('epo', 'epo-not', 'epo-ord', 'epo-cat', 'epo-con', 'epo-ful')"/>
     <!-- This set of variables controls the generation of reused concepts within artifacts. -->
     <xsl:variable name="generateReusedConceptsSHACL" select="fn:true()"/>
     <xsl:variable name="generateReusedConceptsOWLcore" select="fn:true()"/>


### PR DESCRIPTION
The `internalModelPrefixesList` config parameter has been renamed to `includedPrefixesList`.
Related descriptions have been updated to explain the new naming convention.