### PR TITLE
T3: Export of metadata about concepts #229

### DIFF
--- a/src/common/checkers.xsl
+++ b/src/common/checkers.xsl
@@ -419,7 +419,12 @@
 
 
     <xd:doc>
-        <xd:desc>Checks if tag name is an URI</xd:desc>
+        <xd:desc>Checks if tag name is one of the following cases :
+            namespace:localName
+            namespace:localName@en
+            namespace:localName^^xsd:integer
+            namespace:localName&lt;&gt;
+        </xd:desc>
         <xd:param name="tagName"/>
     </xd:doc>
 
@@ -427,7 +432,11 @@
         <xsl:param name="tagName"/>
         <xsl:sequence
             select="
-            if (fn:matches($tagName, '^[a-z][-a-z0-9]*:[-a-zA-Z0-9_]+(?:@[a-zA-Z]+|\\^\\^[-a-zA-Z0-9_]+|&lt;&gt;)?$')) then
+            if (
+            fn:matches($tagName, '^[a-z][-a-z0-9]*:[-a-zA-Z0-9_]+$') or
+            fn:matches($tagName, '^[a-z][-a-z0-9]*:[-a-zA-Z0-9_]+@[a-zA-Z]+$') or
+            fn:matches($tagName, '^[a-z][-a-z0-9]*:[-a-zA-Z0-9]+\^\^[a-z][-a-z0-9]*:[-a-zA-Z0-9]+$') or
+            fn:matches($tagName, '^[a-z][-a-z0-9]*:[-a-zA-Z0-9_]+&lt;&gt;$')) then
                     fn:true()
                 else
                     fn:false()"

--- a/src/common/checkers.xsl
+++ b/src/common/checkers.xsl
@@ -427,7 +427,7 @@
         <xsl:param name="tagName"/>
         <xsl:sequence
             select="
-                if (fn:matches($tagName, '^(:\w+|[a-z][-a-z0-9]*:[-a-zA-Z0-9_@]+)$')) then
+            if (fn:matches($tagName, '^[a-z][-a-z0-9]*:[-a-zA-Z0-9_]+(?:@[a-zA-Z]+|\\^\\^[-a-zA-Z0-9_]+|&lt;&gt;)?$')) then
                     fn:true()
                 else
                     fn:false()"

--- a/src/common/utils.xsl
+++ b/src/common/utils.xsl
@@ -632,5 +632,112 @@
             <xsl:namespace name="{./@name}" select="./@value"/>
         </xsl:for-each>
     </xsl:template>
+    
+    
+    <!-- Grouped Datatypes as Lists -->
+    <xsl:variable name="numericDatatypes" as="xs:string*">
+        <xsl:sequence select="'xsd:integer', 'xsd:decimal', 'xsd:double', 'xsd:float',
+            'xsd:byte', 'xsd:short', 'xsd:int', 'xsd:long',
+            'xsd:negativeInteger', 'xsd:nonNegativeInteger',
+            'xsd:positiveInteger', 'xsd:nonPositiveInteger',
+            'xsd:unsignedByte', 'xsd:unsignedShort',
+            'xsd:unsignedInt', 'xsd:unsignedLong'"/>
+    </xsl:variable>
+    
+    <xsl:variable name="booleanDatatypes" as="xs:string*">
+        <xsl:sequence select="'xsd:boolean'"/>
+    </xsl:variable>
+    
+    <xsl:variable name="dateTimeDatatypes" as="xs:string*">
+        <xsl:sequence select="'xsd:date', 'xsd:time', 'xsd:dateTime', 'xsd:dateTimeStamp'"/>
+    </xsl:variable>
+    
+    <xsl:variable name="stringDatatypes" as="xs:string*">
+        <xsl:sequence select="'xsd:string', 'xsd:normalizedString', 'xsd:token',
+            'xsd:Name', 'xsd:NCName', 'xsd:NMTOKEN',
+            'xsd:language', 'rdf:PlainLiteral', 'rdf:langString'"/>
+    </xsl:variable>
+    
+    
+    <xd:doc>
+        <xd:desc>
+            This function validates the value entered by the user in a tag against its corresponding datatype.
+            
+            Due to XSLT limitations, specifically with the castable as expression, the validation process can't be done dynamically 
+            so multiple datatypes needs to be grouped in the validation process. For instance:
+            
+            Data types such as xsd:integer and xsd:double are grouped under xs:double for validation purposes.
+            Similarly, other related data types are grouped into predefined variables.
+            
+            If a new custom data type is introduced, it must be added to the appropriate grouping variable to ensure validation.
+            This is a workaround due limitations of XSLT
+        </xd:desc>
+        <xd:param name="tagValue"/>
+        <xd:param name="datatypeQName"/>
+    </xd:doc>
+    <xsl:function name="f:validateTagValue" as="xs:boolean">
+        <xsl:param name="tagValue" as="xs:string"/>
+        <xsl:param name="datatypeQName" as="xs:string"/>
+        
+        <!-- Validation based on resolved datatype -->
+        <xsl:choose>
+            <!-- Numeric Types -->
+            <xsl:when test="$datatypeQName = $numericDatatypes">
+                <xsl:if test="not($tagValue castable as xs:double)">
+                    <xsl:sequence select="fn:error(
+                        xs:QName('invalidValueError'),
+                        concat('Error: Value ', $tagValue, ' is not valid for numeric type ', $datatypeQName, '.')
+                        )"/>
+                </xsl:if>
+            </xsl:when>
+            
+            <!-- Boolean Type -->
+            <xsl:when test="$datatypeQName = $booleanDatatypes">
+                <xsl:if test="not($tagValue castable as xs:boolean)">
+                    <xsl:sequence select="fn:error(
+                        xs:QName('invalidValueError'),
+                        concat('Error: Value ', $tagValue, ' is not valid for boolean type ', $datatypeQName, '.')
+                        )"/>
+                </xsl:if>
+            </xsl:when>
+            
+            <!-- Date and Time Types -->
+            <xsl:when test="$datatypeQName = $dateTimeDatatypes">
+                <xsl:if test="not($tagValue castable as xs:dateTime)">
+                    <xsl:sequence select="fn:error(
+                        xs:QName('invalidValueError'),
+                        concat('Error: Value ', $tagValue, ' is not valid for date/time type ', $datatypeQName, '.')
+                        )"/>
+                </xsl:if>
+            </xsl:when>
+            
+            <!-- Strings and Text Types -->
+            <xsl:when test="$datatypeQName = $stringDatatypes">
+                <!-- Strings are always valid -->
+            </xsl:when>
+            
+            <!-- URI Validation -->
+            <xsl:when test="$datatypeQName = 'xsd:anyURI'">
+                <xsl:if test="not($tagValue castable as xs:anyURI)">
+                    <xsl:sequence select="fn:error(
+                        xs:QName('invalidValueError'),
+                        concat('Error: Value ', $tagValue, ' is not a valid URI.')
+                        )"/>
+                </xsl:if>
+            </xsl:when>
+            
+            <!-- Unsupported Types -->
+            <xsl:otherwise>
+                <xsl:sequence select="fn:error(
+                    xs:QName('invalidValueError'),
+                    concat('Error: Unsupported datatype ', $datatypeQName, '.')
+                    )"/>
+            </xsl:otherwise>
+        </xsl:choose>
+        
+        <!-- Return true for valid values -->
+        <xsl:sequence select="fn:true()"/>
+    </xsl:function>
+    
 
 </xsl:stylesheet>

--- a/src/html-conventions-lib/common-elements-html-conventions.xsl
+++ b/src/html-conventions-lib/common-elements-html-conventions.xsl
@@ -341,7 +341,12 @@
 
 
     <xd:doc>
-        <xd:desc>[common-tag-13] - The tag $tagName$ of element $elementName$ must be an URI. </xd:desc>
+        <xd:desc>[common-tag-13] - The tag $tagName$ of element $elementName$ must be one of the following formats:
+            namespace:localName
+            namespace:localName@en
+            namespace:localName^^xsd:integer
+            namespace:localName&lt;&gt;
+        </xd:desc>
         <xd:param name="element"/>
     </xd:doc>
     <xsl:template name="invalidTagName">
@@ -354,7 +359,7 @@
                     if (f:isValidTagName($tag/@name)) then
                         ()
                     else
-                        f:generateErrorMessage(fn:concat('The tag ', $tag/@name, ' of element ', $element/@name, ' must be an URI.'),
+                    f:generateErrorMessage(fn:concat('The tag ', $tag/@name, ' of element ', $element/@name, ' must be one of the following formats: namespace:localName, namespace:localName@en, namespace:localName^^xsd:integer, namespace:localName&lt;&gt;.'),
                         path($element),
                         'common-tag-13',
                         'CMC-R6',

--- a/src/owl-core-lib/descriptors-owl-core.xsl
+++ b/src/owl-core-lib/descriptors-owl-core.xsl
@@ -112,13 +112,15 @@
                     </xsl:element>
                 </xsl:when>
             <xsl:when test="fn:contains($tagName, '^^')">
-                <xsl:variable name="datatype" select="fn:substring-after($tagName, '^^')"/>
-                <xsl:variable name="datatypePrefix" select="fn:substring-before($datatype, ':')"/>
-                <xsl:variable name="datatypeValue" select="fn:substring-after($datatype, ':')"/>
+                <xsl:variable name="datatypeCompactURI" select="fn:substring-after($tagName, '^^')"/>
+                <xsl:variable name="datatypePrefix" select="fn:substring-before($datatypeCompactURI, ':')"/>
+                <xsl:variable name="datatypeLocalName" select="fn:substring-after($datatypeCompactURI, ':')"/>
                 <xsl:variable name="expandedDatatypePrefix" select="f:getNamespaceURI($datatypePrefix)"/>
+                <xsl:if test="f:validateTagValue($tagValue,$datatypeCompactURI)">
+                    
                 
                 <xsl:choose>
-                    <xsl:when test="$datatypeValue='string'">
+                    <xsl:when test="$datatypeLocalName='string'">
                         <xsl:element name="{fn:substring-before($tagName,'^^')}" namespace="{f:getNamespaceURI(fn:substring-before($tagName, ':'))}">
                             <xsl:value-of select="$tagValue"/>
                         </xsl:element>
@@ -126,20 +128,23 @@
                     <xsl:otherwise>
                         <xsl:element name="{fn:substring-before($tagName,'^^')}" namespace="{f:getNamespaceURI(fn:substring-before($tagName, ':'))}">
                             <xsl:attribute name="rdf:datatype">
-                                <xsl:value-of select="fn:concat($expandedDatatypePrefix,$datatypeValue)"/>
+                                <xsl:value-of select="fn:concat($expandedDatatypePrefix,$datatypeLocalName)"/>
                             </xsl:attribute>
                             <xsl:value-of select="$tagValue"/>
                         </xsl:element>
                     </xsl:otherwise>
                 </xsl:choose>
+                </xsl:if>
             </xsl:when>
             <xsl:when test="fn:contains($tagName, '&lt;&gt;')">
+                <xsl:if test="f:validateTagValue($tagValue,'xsd:anyURI')">
                 <xsl:variable name="tagPrefix" select="fn:substring-before($tagName, ':')"/>
                 <xsl:element name="{fn:substring-before($tagName,'&lt;&gt;')}" namespace="{f:getNamespaceURI(fn:substring-before($tagName, ':'))}">
                     <xsl:attribute name="rdf:resource">
                         <xsl:value-of select="$tagValue"/>
                     </xsl:attribute>
                 </xsl:element>
+                </xsl:if>
             </xsl:when>
             <xsl:otherwise>
                 <xsl:element name="{$tagName}" namespace="{f:getNamespaceURI(fn:substring-before($tagName, ':'))}">
@@ -152,6 +157,8 @@
         </xsl:choose>      
         </rdf:Description>
     </xsl:template>
+    
+    
     
 
 </xsl:stylesheet>

--- a/src/owl-core-lib/descriptors-owl-core.xsl
+++ b/src/owl-core-lib/descriptors-owl-core.xsl
@@ -120,7 +120,7 @@
                     
                 
                 <xsl:choose>
-                    <xsl:when test="$datatypeLocalName='string'">
+                    <xsl:when test="$datatypeCompactURI=$stringDatatypes">
                         <xsl:element name="{fn:substring-before($tagName,'^^')}" namespace="{f:getNamespaceURI(fn:substring-before($tagName, ':'))}">
                             <xsl:value-of select="$tagValue"/>
                         </xsl:element>

--- a/test/unitTests/test-common/test-checkers.xspec
+++ b/test/unitTests/test-common/test-checkers.xspec
@@ -451,5 +451,45 @@
         <x:expect label="a list with namespaces that were not defined" select="('twe', 'cancan')"/>
     </x:scenario>
     
+    <x:scenario label="Tests for f:isValidTagName">
+        <x:scenario label="valid tag with lang tag">
+            <x:call function="f:isValidTagName">
+                <x:param name="tagName" select="'skos:note@en'"/>
+            </x:call>
+            <x:expect label="valid tag name with lang tag" select="true()"/>
+        </x:scenario>
+        <x:scenario label="valid tag with datatype">
+            <x:call function="f:isValidTagName">
+                <x:param name="tagName" select="'skos:version^^xsd:integer'"/>
+            </x:call>
+            <x:expect label="valid with datatype" select="true()"/>
+        </x:scenario>
+        <x:scenario label="valid tag">
+            <x:call function="f:isValidTagName">
+                <x:param name="tagName" select="'skos:note'"/>
+            </x:call>
+            <x:expect label="valid tag name" select="true()"/>
+        </x:scenario>
+        <x:scenario label="valid tag with uri">
+            <x:call function="f:isValidTagName">
+                <x:param name="tagName" select="'skos:indentifier&lt;&gt;'"/>
+            </x:call>
+            <x:expect label="valid tag name with URI" select="true()"/>
+        </x:scenario>
+        
+        <x:scenario label="invalid tag">
+            <x:call function="f:isValidTagName">
+                <x:param name="tagName" select="'indentifier'"/>
+            </x:call>
+            <x:expect label="invalid" select="false()"/>
+        </x:scenario>
+        <x:scenario label="invalid tag datatytpe">
+            <x:call function="f:isValidTagName">
+                <x:param name="tagName" select="'skos:version^^'"/>
+            </x:call>
+            <x:expect label="invalid" select="false()"/>
+        </x:scenario>
+    </x:scenario>
+    
 </x:description>
 

--- a/test/unitTests/test-common/test-utils.xspec
+++ b/test/unitTests/test-common/test-utils.xspec
@@ -337,21 +337,17 @@
             <x:expect label="result" select="fn:true()"/>
         </x:scenario>
         
-        <x:scenario label="invalid URI" catch="yes">
-            <x:call function="f:validateTagValue">
-                <x:param name="tagValue" select="'invalid_uri'"/>
-                <x:param name="datatypeQName" select="'xsd:anyURI'"/>
-            </x:call>
-        </x:scenario>
-        
         <x:scenario label="invalid integer" catch="yes">
             <x:call function="f:validateTagValue">
                 <x:param name="tagValue" select="'integer'"/>
-                <x:param name="datatypeQName" select="'xsd:int'"/>  
+                <x:param name="datatypeQName" select="'xsd:int'"/> 
             </x:call>
+            <x:expect label="err:description" test="boolean($x:result?err?description)"/>
         </x:scenario>
 
     </x:scenario>
+    
+
 
 
     <x:scenario label="Scenario for testing function buildPropertyShapeURI">

--- a/test/unitTests/test-common/test-utils.xspec
+++ b/test/unitTests/test-common/test-utils.xspec
@@ -311,6 +311,47 @@
         </x:call>
         <x:expect label="result" select="fn:true()"/>
     </x:scenario>
+    
+    <x:scenario label="Scenario for testing function f:validateTagValue ">
+        <x:scenario label="valid boolean">
+            <x:call function="f:validateTagValue">
+                <x:param name="tagValue" select="'true'"/>
+                <x:param name="datatypeQName" select="'xsd:boolean'"/>
+            </x:call>
+            <x:expect label="result" select="fn:true()"/>
+        </x:scenario>
+        
+        <x:scenario label="valid integer">
+            <x:call function="f:validateTagValue">
+                <x:param name="tagValue" select="'2'"/>
+                <x:param name="datatypeQName" select="'xsd:int'"/>
+            </x:call>
+            <x:expect label="result" select="fn:true()"/>
+        </x:scenario>
+        
+        <x:scenario label="valid URI">
+            <x:call function="f:validateTagValue">
+                <x:param name="tagValue" select="'http://www.w3.org/2001/XMLSchema#string'"/>
+                <x:param name="datatypeQName" select="'xsd:anyURI'"/>
+            </x:call>
+            <x:expect label="result" select="fn:true()"/>
+        </x:scenario>
+        
+        <x:scenario label="invalid URI" catch="yes">
+            <x:call function="f:validateTagValue">
+                <x:param name="tagValue" select="'invalid_uri'"/>
+                <x:param name="datatypeQName" select="'xsd:anyURI'"/>
+            </x:call>
+        </x:scenario>
+        
+        <x:scenario label="invalid integer" catch="yes">
+            <x:call function="f:validateTagValue">
+                <x:param name="tagValue" select="'integer'"/>
+                <x:param name="datatypeQName" select="'xsd:int'"/>  
+            </x:call>
+        </x:scenario>
+
+    </x:scenario>
 
 
     <x:scenario label="Scenario for testing function buildPropertyShapeURI">

--- a/test/unitTests/test-html-conventions-lib/test-common-elements-html-conventions.xspec
+++ b/test/unitTests/test-html-conventions-lib/test-common-elements-html-conventions.xspec
@@ -311,7 +311,7 @@
         <x:call template="invalidTagName">
             <x:param name="element" href="../../testData/ePO_core_with_tags.xml" select="/xmi:XMI/xmi:Extension[1]/elements[1]/element[211]"/>
         </x:call>   
-        <x:expect label="expect a Description Element" test="count(/dd)=3"/> 
+        <x:expect label="expect a Description Element" test="count(/dd)=4"/> 
     </x:scenario>
     
     <x:scenario label="Scenario for finding a tag without name in a class ">


### PR DESCRIPTION
1. Tags Transformation

Support for tags transformation has been added with four different representations based on suffixes:

   * Default: Treated as plain text literal.
   * @LANG: Language suffix for specifying a language tag.
   * ^^DATATYPE: Data type suffix for specifying custom data types.
   * <>: URI suffix for specifying a URI.

2. Comments Generation

Two new configuration parameters have been introduced to control comments generation:

    * commentsGeneration: A boolean value controlling whether or not comment statements will be generated.
    * commentProperty: A literal representing a compact URI to be used as the property in RDF statements for describing a comment.