### PR TITLE
T1: Implement "Status-based filtering" feature #226

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -326,3 +326,4 @@ pyvenv.cfg
 /build/
 /node_modules/
 .temp
+/enf/

--- a/src/common/fetchers.xsl
+++ b/src/common/fetchers.xsl
@@ -330,6 +330,16 @@
     </xsl:function>
     
     <xd:doc>
+        <xd:desc>Fetch all tags for a connector, including source, target, and connector-level tags</xd:desc>
+        <xd:param name="connector"/>
+    </xd:doc>
+    <xsl:function name="f:getConnectorTags">
+        <xsl:param name="connector"/>
+        <!-- Fetch all tags from source, target, and connector level -->
+        <xsl:sequence select="$connector//tags/tag" />
+    </xsl:function>
+    
+    <xd:doc>
         <xd:desc> Fetch role name value from a connector. It can be either in source or in target</xd:desc>
         <xd:param name="connector"/>
     </xd:doc>

--- a/src/common/selectors.xsl
+++ b/src/common/selectors.xsl
@@ -25,14 +25,14 @@
     <xsl:template match="xmi:XMI">
         <xsl:apply-templates select="/xmi:XMI/xmi:Extension/elements"/>
         <xsl:apply-templates select="/xmi:XMI/xmi:Extension/connectors"/>
-        <xsl:apply-templates select="/xmi:XMI/uml:Model/packagedElement//ownedComment"/>
+        <xsl:apply-templates select="/xmi:XMI//packagedElement//ownedComment"/>
     </xsl:template>
     
     <xd:doc>
         <xd:desc>This template target floating comments in the model</xd:desc>
     </xd:doc>
     <xsl:template match="ownedComment">
-        <xsl:apply-templates select="ownedComment[@xmi:type='uml:Comment']"/>
+        <xsl:apply-templates select="ownedComment[@xmi:type = 'uml:Comment']"/>
     </xsl:template>
 
     <xd:doc>

--- a/src/common/utils.xsl
+++ b/src/common/utils.xsl
@@ -656,7 +656,6 @@
         <xsl:variable name="statusTag" select="
             for $tag in $tags
             return if ($tag/@name = $statusProperty) then $tag else ()"/>
-        <xsl:message>Status Tag: <xsl:copy-of select="$statusTag"/></xsl:message>
         <!-- Extract the value of the status tag -->
         <xsl:variable name="statusValue" select="$statusTag/@value"/>
 
@@ -667,7 +666,6 @@
                     select="$nodeInput/@xmi:id"/>". Allowed values are: <xsl:value-of
                     select="string-join($validStatusesList, ', ')"/>. </xsl:message>
         </xsl:if>
-<xsl:message><xsl:value-of select="fn:concat('Status is ', $statusValue)"/></xsl:message>
         <!-- Determine if the element should be excluded -->
         <xsl:sequence
             select="

--- a/src/common/utils.xsl
+++ b/src/common/utils.xsl
@@ -632,5 +632,51 @@
             <xsl:namespace name="{./@name}" select="./@value"/>
         </xsl:for-each>
     </xsl:template>
+    
+    <xd:doc>
+        <xd:desc>This template will return true or false if the an element should be filtered or not by looking at 
+        the status value
+        :nodeInput can be an element or connector
+        </xd:desc>
+        <xd:param name="nodeInput"/>
+    </xd:doc>
+    
+    <xsl:function name="f:isExcludedByStatus">
+        <xsl:param name="nodeInput" as="node()*"/>
+        
+        <!-- Get all tags for the element -->
+        <xsl:variable name="tags"
+            select="
+                if (local-name($nodeInput) = 'connector') then
+                    f:getConnectorTags($nodeInput)
+                else
+                    f:getElementTags($nodeInput)"/>
+        
+        <!-- Find the status tag -->
+        <xsl:variable name="statusTag" select="
+            for $tag in $tags
+            return if ($tag/@name = $statusProperty) then $tag else ()"/>
+        <xsl:message>Status Tag: <xsl:copy-of select="$statusTag"/></xsl:message>
+        <!-- Extract the value of the status tag -->
+        <xsl:variable name="statusValue" select="$statusTag/@value"/>
+
+        <!-- Validation: Ensure statusValue is in validStatusesList -->
+        <xsl:if test="$statusValue and not($statusValue = $validStatusesList)">
+            <xsl:message terminate="yes"> Error: Invalid status value "<xsl:value-of
+                    select="$statusValue"/>" for element with ID "<xsl:value-of
+                    select="$nodeInput/@xmi:id"/>". Allowed values are: <xsl:value-of
+                    select="string-join($validStatusesList, ', ')"/>. </xsl:message>
+        </xsl:if>
+<xsl:message><xsl:value-of select="fn:concat('Status is ', $statusValue)"/></xsl:message>
+        <!-- Determine if the element should be excluded -->
+        <xsl:sequence
+            select="
+                if (not($statusValue)) then
+                    $unspecifiedStatusInterpretation = $excludedElementStatusesList
+                else
+                    $statusValue = $excludedElementStatusesList
+                "
+        />
+    </xsl:function>
 
 </xsl:stylesheet>

--- a/src/common/utils.xsl
+++ b/src/common/utils.xsl
@@ -637,6 +637,11 @@
         <xd:desc>This template will return true or false if the an element should be filtered or not by looking at 
         the status value
         :nodeInput can be an element or connector
+        - If a `statusValue` is provided, it checks whether the value is part of the `excludedElementStatusesList`.
+        - If no `statusValue` is provided (i.e., the status is undefined), the function falls back to using
+          the `unspecifiedStatusInterpretation` as the default status value. It then checks whether this default
+          status is part of the `excludedElementStatusesList`.
+
         </xd:desc>
         <xd:param name="nodeInput"/>
     </xd:doc>

--- a/src/owl-core-lib/connectors-owl-core.xsl
+++ b/src/owl-core-lib/connectors-owl-core.xsl
@@ -43,6 +43,7 @@
     </xd:doc>
     <xsl:template match="connector[./properties/@ea_type = 'Realisation']">
         <xsl:if test="$generateObjectsAndRealisations">
+            <xsl:if test="not(f:isExcludedByStatus(.))">
             <!-- Extract prefixes for source and target -->
             <xsl:variable name="sourcePrefix"
                 select="fn:substring-before(./source/model/@name, ':')"/>
@@ -56,6 +57,7 @@
                     <xsl:with-param name="realisation" select="."/>
                 </xsl:call-template>
             </xsl:if>
+            </xsl:if>
         </xsl:if>
     </xsl:template>
 
@@ -64,12 +66,14 @@
         <xd:desc/>
     </xd:doc>
     <xsl:template match="connector[./properties/@ea_type = 'Generalization']">
+        <xsl:if test="not(f:isExcludedByStatus(.))">
         <!--        This reused concepts filter is applied in the propertyGeneralization function due complexity of the function-->
         <xsl:if
             test="
                 ./source/model/@type = 'ProxyConnector' and
                 ./target/model/@type = 'ProxyConnector'">
             <xsl:call-template name="propertyGeneralization"/>
+        </xsl:if>
         </xsl:if>
     </xsl:template>
 
@@ -81,13 +85,14 @@
         <xsl:variable name="generalisations"
             select="//connector[./properties/@ea_type = 'Generalization'][not(target/@xmi:idref = preceding::connector[./properties/@ea_type = 'Generalization']/target/@xmi:idref)]"/>
         <xsl:for-each select="$generalisations">
-
+            <xsl:if test="not(f:isExcludedByStatus(.))">
             <xsl:if
                 test="
                     ./source/model/@type = 'Class' and
                     ./target/model/@type = 'Class'">
 <!--                    This reused concepts filter is applied in the template so that the subclasses are also filtered-->
                     <xsl:call-template name="classGeneralization"/>
+            </xsl:if>
             </xsl:if>
         </xsl:for-each>
     </xsl:template>
@@ -199,6 +204,7 @@
         <xsl:variable name="root" select="root()"/>
         <xsl:variable name="distinctNames" select="f:getDistinctConnectorsNames($root)"/>
         <xsl:for-each select="$distinctNames">
+            <xsl:if test="not(f:isExcludedByStatus(f:getConnectorByName(., $root)[1]))">
             <xsl:if
                 test="
                     f:getConnectorByName(., $root)/source/model/@type != 'ProxyConnector' and f:getConnectorByName(., $root)/target/model/@type != 'ProxyConnector'
@@ -214,6 +220,7 @@
                     </xsl:call-template>
                 </xsl:if>
 
+            </xsl:if>
             </xsl:if>
         </xsl:for-each>
     </xsl:template>

--- a/src/owl-core-lib/descriptors-owl-core.xsl
+++ b/src/owl-core-lib/descriptors-owl-core.xsl
@@ -66,14 +66,15 @@
         <rdf:Description rdf:about="{$elementUri}">
             <xsl:element name="{$commentProperty}">
                 <xsl:attribute name="xml:lang">en</xsl:attribute>
-                 <xsl:value-of select="fn:normalize-space($comment)"/>
+                <xsl:value-of select="fn:normalize-space($comment)"/>
             </xsl:element>
         </rdf:Description>
     </xsl:template>
 
 
     <xd:doc>
-        <xd:desc>Rule T.08. Annotate all locally defined OWL concepts with the name of the (core) ontology that defines them.</xd:desc>
+        <xd:desc>Rule T.08. Annotate all locally defined OWL concepts with the name of the (core)
+            ontology that defines them.</xd:desc>
         <xd:param name="elementUri"/>
     </xd:doc>
     <xsl:template name="coreDefinedBy">
@@ -84,11 +85,12 @@
             </rdf:Description>
         </xsl:if>
     </xsl:template>
-    
-    
+
+
     <xd:doc>
-        <xd:desc>Rule T.07. Tag — in core ontology layer. Specify an annotation axiom on the OWL entity for each UML Tag associated to a UML element.
-            If a tag has an associated language tag, it should be attached to the value.</xd:desc>
+        <xd:desc>Rule T.07. Tag — in core ontology layer. Specify an annotation axiom on the OWL
+            entity for each UML Tag associated to a UML element. If a tag has an associated language
+            tag, it should be attached to the value.</xd:desc>
         <xd:param name="elementUri"/>
         <xd:param name="tagName"/>
         <xd:param name="tagValue"/>
@@ -97,61 +99,73 @@
         <xsl:param name="tagName"/>
         <xsl:param name="tagValue"/>
         <xsl:param name="elementUri"/>
+        <xsl:if test="not($tagName = $statusProperty)">
+            <rdf:Description rdf:about="{$elementUri}">
 
-        <rdf:Description rdf:about="{$elementUri}">
-        <xsl:choose>
-            <xsl:when test="fn:contains($tagName, '@')">
-                    <xsl:variable name="langTag" select="fn:substring-after($tagName, '@')"/>
-                    <xsl:variable name="normalisedTagName"
-                        select="fn:substring-before($tagName, '@')"/>
-                <xsl:element name="{$normalisedTagName}" namespace="{f:getNamespaceURI(fn:substring-before($tagName, ':'))}">
-                        <xsl:attribute name="xml:lang">
-                            <xsl:value-of select="$langTag"/>
-                        </xsl:attribute>
-                        <xsl:value-of select="$tagValue"/>
-                    </xsl:element>
-                </xsl:when>
-            <xsl:when test="fn:contains($tagName, '^^')">
-                <xsl:variable name="datatype" select="fn:substring-after($tagName, '^^')"/>
-                <xsl:variable name="datatypePrefix" select="fn:substring-before($datatype, ':')"/>
-                <xsl:variable name="datatypeValue" select="fn:substring-after($datatype, ':')"/>
-                <xsl:variable name="expandedDatatypePrefix" select="f:getNamespaceURI($datatypePrefix)"/>
-                
                 <xsl:choose>
-                    <xsl:when test="$datatypeValue='string'">
-                        <xsl:element name="{fn:substring-before($tagName,'^^')}" namespace="{f:getNamespaceURI(fn:substring-before($tagName, ':'))}">
+                    <xsl:when test="fn:contains($tagName, '@')">
+                        <xsl:variable name="langTag" select="fn:substring-after($tagName, '@')"/>
+                        <xsl:variable name="normalisedTagName"
+                            select="fn:substring-before($tagName, '@')"/>
+                        <xsl:element name="{$normalisedTagName}"
+                            namespace="{f:getNamespaceURI(fn:substring-before($tagName, ':'))}">
+                            <xsl:attribute name="xml:lang">
+                                <xsl:value-of select="$langTag"/>
+                            </xsl:attribute>
                             <xsl:value-of select="$tagValue"/>
                         </xsl:element>
                     </xsl:when>
+                    <xsl:when test="fn:contains($tagName, '^^')">
+                        <xsl:variable name="datatype" select="fn:substring-after($tagName, '^^')"/>
+                        <xsl:variable name="datatypePrefix"
+                            select="fn:substring-before($datatype, ':')"/>
+                        <xsl:variable name="datatypeValue"
+                            select="fn:substring-after($datatype, ':')"/>
+                        <xsl:variable name="expandedDatatypePrefix"
+                            select="f:getNamespaceURI($datatypePrefix)"/>
+
+                        <xsl:choose>
+                            <xsl:when test="$datatypeValue = 'string'">
+                                <xsl:element name="{fn:substring-before($tagName,'^^')}"
+                                    namespace="{f:getNamespaceURI(fn:substring-before($tagName, ':'))}">
+                                    <xsl:value-of select="$tagValue"/>
+                                </xsl:element>
+                            </xsl:when>
+                            <xsl:otherwise>
+                                <xsl:element name="{fn:substring-before($tagName,'^^')}"
+                                    namespace="{f:getNamespaceURI(fn:substring-before($tagName, ':'))}">
+                                    <xsl:attribute name="rdf:datatype">
+                                        <xsl:value-of
+                                            select="fn:concat($expandedDatatypePrefix, $datatypeValue)"
+                                        />
+                                    </xsl:attribute>
+                                    <xsl:value-of select="$tagValue"/>
+                                </xsl:element>
+                            </xsl:otherwise>
+                        </xsl:choose>
+                    </xsl:when>
+                    <xsl:when test="fn:contains($tagName, '&lt;&gt;')">
+                        <xsl:variable name="tagPrefix" select="fn:substring-before($tagName, ':')"/>
+                        <xsl:element name="{fn:substring-before($tagName,'&lt;&gt;')}"
+                            namespace="{f:getNamespaceURI(fn:substring-before($tagName, ':'))}">
+                            <xsl:attribute name="rdf:resource">
+                                <xsl:value-of select="$tagValue"/>
+                            </xsl:attribute>
+                        </xsl:element>
+                    </xsl:when>
                     <xsl:otherwise>
-                        <xsl:element name="{fn:substring-before($tagName,'^^')}" namespace="{f:getNamespaceURI(fn:substring-before($tagName, ':'))}">
-                            <xsl:attribute name="rdf:datatype">
-                                <xsl:value-of select="fn:concat($expandedDatatypePrefix,$datatypeValue)"/>
+                        <xsl:element name="{$tagName}"
+                            namespace="{f:getNamespaceURI(fn:substring-before($tagName, ':'))}">
+                            <xsl:attribute name="xml:lang">
+                                <xsl:value-of select="'en'"/>
                             </xsl:attribute>
                             <xsl:value-of select="$tagValue"/>
                         </xsl:element>
                     </xsl:otherwise>
                 </xsl:choose>
-            </xsl:when>
-            <xsl:when test="fn:contains($tagName, '&lt;&gt;')">
-                <xsl:variable name="tagPrefix" select="fn:substring-before($tagName, ':')"/>
-                <xsl:element name="{fn:substring-before($tagName,'&lt;&gt;')}" namespace="{f:getNamespaceURI(fn:substring-before($tagName, ':'))}">
-                    <xsl:attribute name="rdf:resource">
-                        <xsl:value-of select="$tagValue"/>
-                    </xsl:attribute>
-                </xsl:element>
-            </xsl:when>
-            <xsl:otherwise>
-                <xsl:element name="{$tagName}" namespace="{f:getNamespaceURI(fn:substring-before($tagName, ':'))}">
-                    <xsl:attribute name="xml:lang">
-                        <xsl:value-of select="'en'"/>
-                    </xsl:attribute>
-                    <xsl:value-of select="$tagValue"/>
-                </xsl:element>
-            </xsl:otherwise>
-        </xsl:choose>      
-        </rdf:Description>
+            </rdf:Description>
+        </xsl:if>
     </xsl:template>
-    
+
 
 </xsl:stylesheet>

--- a/src/owl-core-lib/descriptors-owl-core.xsl
+++ b/src/owl-core-lib/descriptors-owl-core.xsl
@@ -104,7 +104,7 @@
                     <xsl:variable name="langTag" select="fn:substring-after($tagName, '@')"/>
                     <xsl:variable name="normalisedTagName"
                         select="fn:substring-before($tagName, '@')"/>
-                <xsl:element name="{$normalisedTagName}">
+                <xsl:element name="{$normalisedTagName}" namespace="{f:getNamespaceURI(fn:substring-before($tagName, ':'))}">
                         <xsl:attribute name="xml:lang">
                             <xsl:value-of select="$langTag"/>
                         </xsl:attribute>
@@ -119,12 +119,12 @@
                 
                 <xsl:choose>
                     <xsl:when test="$datatypeValue='string'">
-                        <xsl:element name="{fn:substring-before($tagName,'^^')}">
+                        <xsl:element name="{fn:substring-before($tagName,'^^')}" namespace="{f:getNamespaceURI(fn:substring-before($tagName, ':'))}">
                             <xsl:value-of select="$tagValue"/>
                         </xsl:element>
                     </xsl:when>
                     <xsl:otherwise>
-                        <xsl:element name="{fn:substring-before($tagName,'^^')}">
+                        <xsl:element name="{fn:substring-before($tagName,'^^')}" namespace="{f:getNamespaceURI(fn:substring-before($tagName, ':'))}">
                             <xsl:attribute name="rdf:datatype">
                                 <xsl:value-of select="fn:concat($expandedDatatypePrefix,$datatypeValue)"/>
                             </xsl:attribute>
@@ -135,14 +135,14 @@
             </xsl:when>
             <xsl:when test="fn:contains($tagName, '&lt;&gt;')">
                 <xsl:variable name="tagPrefix" select="fn:substring-before($tagName, ':')"/>
-                <xsl:element name="{fn:substring-before($tagName,'&lt;&gt;')}">
+                <xsl:element name="{fn:substring-before($tagName,'&lt;&gt;')}" namespace="{f:getNamespaceURI(fn:substring-before($tagName, ':'))}">
                     <xsl:attribute name="rdf:resource">
                         <xsl:value-of select="$tagValue"/>
                     </xsl:attribute>
                 </xsl:element>
             </xsl:when>
             <xsl:otherwise>
-                <xsl:element name="{$tagName}">
+                <xsl:element name="{$tagName}" namespace="{f:getNamespaceURI(fn:substring-before($tagName, ':'))}">
                     <xsl:attribute name="xml:lang">
                         <xsl:value-of select="'en'"/>
                     </xsl:attribute>

--- a/src/owl-core-lib/elements-owl-core.xsl
+++ b/src/owl-core-lib/elements-owl-core.xsl
@@ -37,64 +37,67 @@
     </xd:doc>
     <xsl:template match="ownedComment[@xmi:type = 'uml:Comment']">
         <xsl:if test="$commentsGeneration">
-        <xsl:variable name="commentText" select="./@body"/>
-        <xsl:for-each select="./annotatedElement/@xmi:idref">
-            <xsl:variable name="elementFound" select="f:getElementByIdRef(., root(.))"/>
-            <xsl:if test="boolean($elementFound) and $elementFound/@xmi:type != 'uml:Package'">
-                <xsl:variable name="elementUri" select="f:buildURIFromElement($elementFound)"/>
-                <xsl:call-template name="coreLayerComment">
-                    <xsl:with-param name="elementUri" select="$elementUri"/>
-                    <xsl:with-param name="comment" select="$commentText"/>
-                </xsl:call-template>
-            </xsl:if>
-            <xsl:variable name="connectorFound" select="f:getConnectorByIdRef(., root(.))"/>
-            <xsl:if test="fn:boolean($connectorFound)">
-                <xsl:variable name="connectorDirection"
-                    select="$connectorFound/properties/@direction"/>
-                <xsl:choose>
-                    <xsl:when test="$connectorDirection = 'Source -&gt; Destination'">
-                        <xsl:variable name="connectorTargetRoleUri"
-                            select="
-                                if ($connectorFound/target/role/not(@name) = fn:true()) then
-                                    ()
-                                else
-                                    f:buildURIfromLexicalQName($connectorFound/target/role/@name)"/>
-                        <xsl:if test="boolean($connectorTargetRoleUri)">
-                            <xsl:call-template name="coreLayerComment">
-                                <xsl:with-param name="elementUri" select="$connectorTargetRoleUri"/>
-                                <xsl:with-param name="comment" select="$commentText"/>
-                            </xsl:call-template>
-                        </xsl:if>
-                    </xsl:when>
-                    <xsl:otherwise>
-                        <xsl:variable name="connectorTargetRoleUri"
-                            select="
-                                if ($connectorFound/target/role/not(@name) = fn:true()) then
-                                    ()
-                                else
-                                    f:buildURIfromLexicalQName($connectorFound/target/role/@name)"/>
-                        <xsl:variable name="connectorSourceRoleUri"
-                            select="
-                                if ($connectorFound/source/role/not(@name) = fn:true()) then
-                                    ()
-                                else
-                                    f:buildURIfromLexicalQName($connectorFound/source/role/@name)"/>
-                        <xsl:if test="boolean($connectorSourceRoleUri)">
-                            <xsl:call-template name="coreLayerComment">
-                                <xsl:with-param name="elementUri" select="$connectorSourceRoleUri"/>
-                                <xsl:with-param name="comment" select="$commentText"/>
-                            </xsl:call-template>
-                        </xsl:if>
-                        <xsl:if test="boolean($connectorTargetRoleUri)">
-                            <xsl:call-template name="coreLayerComment">
-                                <xsl:with-param name="elementUri" select="$connectorTargetRoleUri"/>
-                                <xsl:with-param name="comment" select="$commentText"/>
-                            </xsl:call-template>
-                        </xsl:if>
-                    </xsl:otherwise>
-                </xsl:choose>
-            </xsl:if>
-        </xsl:for-each>
+            <xsl:variable name="commentText" select="./@body"/>
+            <xsl:for-each select="./annotatedElement/@xmi:idref">
+                <xsl:variable name="elementFound" select="f:getElementByIdRef(., root(.))"/>
+                <xsl:if test="boolean($elementFound) and $elementFound/@xmi:type != 'uml:Package'">
+                    <xsl:variable name="elementUri" select="f:buildURIFromElement($elementFound)"/>
+                    <xsl:call-template name="coreLayerComment">
+                        <xsl:with-param name="elementUri" select="$elementUri"/>
+                        <xsl:with-param name="comment" select="$commentText"/>
+                    </xsl:call-template>
+                </xsl:if>
+                <xsl:variable name="connectorFound" select="f:getConnectorByIdRef(., root(.))"/>
+                <xsl:if test="fn:boolean($connectorFound)">
+                    <xsl:variable name="connectorDirection"
+                        select="$connectorFound/properties/@direction"/>
+                    <xsl:choose>
+                        <xsl:when test="$connectorDirection = 'Source -&gt; Destination'">
+                            <xsl:variable name="connectorTargetRoleUri"
+                                select="
+                                    if ($connectorFound/target/role/not(@name) = fn:true()) then
+                                        ()
+                                    else
+                                        f:buildURIfromLexicalQName($connectorFound/target/role/@name)"/>
+                            <xsl:if test="boolean($connectorTargetRoleUri)">
+                                <xsl:call-template name="coreLayerComment">
+                                    <xsl:with-param name="elementUri"
+                                        select="$connectorTargetRoleUri"/>
+                                    <xsl:with-param name="comment" select="$commentText"/>
+                                </xsl:call-template>
+                            </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                            <xsl:variable name="connectorTargetRoleUri"
+                                select="
+                                    if ($connectorFound/target/role/not(@name) = fn:true()) then
+                                        ()
+                                    else
+                                        f:buildURIfromLexicalQName($connectorFound/target/role/@name)"/>
+                            <xsl:variable name="connectorSourceRoleUri"
+                                select="
+                                    if ($connectorFound/source/role/not(@name) = fn:true()) then
+                                        ()
+                                    else
+                                        f:buildURIfromLexicalQName($connectorFound/source/role/@name)"/>
+                            <xsl:if test="boolean($connectorSourceRoleUri)">
+                                <xsl:call-template name="coreLayerComment">
+                                    <xsl:with-param name="elementUri"
+                                        select="$connectorSourceRoleUri"/>
+                                    <xsl:with-param name="comment" select="$commentText"/>
+                                </xsl:call-template>
+                            </xsl:if>
+                            <xsl:if test="boolean($connectorTargetRoleUri)">
+                                <xsl:call-template name="coreLayerComment">
+                                    <xsl:with-param name="elementUri"
+                                        select="$connectorTargetRoleUri"/>
+                                    <xsl:with-param name="comment" select="$commentText"/>
+                                </xsl:call-template>
+                            </xsl:if>
+                        </xsl:otherwise>
+                    </xsl:choose>
+                </xsl:if>
+            </xsl:for-each>
         </xsl:if>
     </xsl:template>
 
@@ -105,12 +108,13 @@
         <xd:desc> Selector to run core layer transformation rules for classes</xd:desc>
     </xd:doc>
     <xsl:template match="element[@xmi:type = 'uml:Class']">
-        <xsl:variable name="classPrefix" select="fn:substring-before(./@name, ':')"/>
-        <!-- Check if the class should be processed -->
-        <xsl:if test="$generateReusedConceptsOWLcore or $classPrefix = $includedPrefixesList">
-            <xsl:call-template name="classDeclaration"/>
+        <xsl:if test="not(f:isExcludedByStatus(.))">
+            <xsl:variable name="classPrefix" select="fn:substring-before(./@name, ':')"/>
+            <!-- Check if the class should be processed -->
+            <xsl:if test="$generateReusedConceptsOWLcore or $classPrefix = $includedPrefixesList">
+                <xsl:call-template name="classDeclaration"/>
+            </xsl:if>
         </xsl:if>
-
     </xsl:template>
 
     <xd:doc>
@@ -168,6 +172,7 @@
         <xsl:variable name="root" select="root()"/>
         <xsl:variable name="distinctNames" select="f:getDistinctClassAttributeNames($root)"/>
         <xsl:for-each select="$distinctNames">
+            <xsl:if test="not(f:isExcludedByStatus(f:getClassAttributeByName(., $root)[1]))">
             <!-- Extract the prefix from the attribute name -->
             <xsl:variable name="attributePrefix" select="fn:substring-before(., ':')"/>
 
@@ -178,6 +183,7 @@
                     <xsl:with-param name="attributeName" select="."/>
                     <xsl:with-param name="root" select="$root"/>
                 </xsl:call-template>
+            </xsl:if>
             </xsl:if>
         </xsl:for-each>
     </xsl:template>
@@ -282,12 +288,12 @@
         </xd:desc>
     </xd:doc>
     <xsl:template match="element[@xmi:type = 'uml:DataType']">
+        <xsl:if test="not(f:isExcludedByStatus(.))">
         <!-- Extract the prefix from the DataType name -->
         <xsl:variable name="dataTypePrefix" select="fn:substring-before(./@name, ':')"/>
 
         <!-- Check if the DataType should be processed -->
-        <xsl:if
-            test="$generateReusedConceptsOWLcore or $dataTypePrefix = $includedPrefixesList">
+        <xsl:if test="$generateReusedConceptsOWLcore or $dataTypePrefix = $includedPrefixesList">
             <xsl:choose>
                 <xsl:when test="not(attributes)">
                     <xsl:call-template name="datatypeDeclaration"/>
@@ -296,6 +302,7 @@
                     <xsl:call-template name="classDeclaration"/>
                 </xsl:otherwise>
             </xsl:choose>
+        </xsl:if>
         </xsl:if>
     </xsl:template>
 
@@ -347,8 +354,10 @@
     </xd:doc>
     <xsl:template match="element[@xmi:type = 'uml:Enumeration']">
         <xsl:if test="$enableGenerationOfConceptSchemes">
+            <xsl:if test="not(f:isExcludedByStatus(.))">
             <xsl:variable name="conceptSchemeName" select="./@name"/>
-            <xsl:variable name="enumerationPrefix" select="fn:substring-before($conceptSchemeName, ':')"/>
+            <xsl:variable name="enumerationPrefix"
+                select="fn:substring-before($conceptSchemeName, ':')"/>
             <!-- Check if the Enumeration should be processed -->
             <xsl:if
                 test="$generateReusedConceptsOWLcore or $enumerationPrefix = $includedPrefixesList">
@@ -357,33 +366,34 @@
                     select="fn:normalize-space(f:formatDocString(./properties/@documentation))"/>
 
 
-                    <skos:ConceptScheme rdf:about="{$conceptSchemeURI}"/>
+                <skos:ConceptScheme rdf:about="{$conceptSchemeURI}"/>
 
-                    <xsl:call-template name="coreLayerName">
-                        <xsl:with-param name="elementName" select="$conceptSchemeName"/>
+                <xsl:call-template name="coreLayerName">
+                    <xsl:with-param name="elementName" select="$conceptSchemeName"/>
+                    <xsl:with-param name="elementUri" select="$conceptSchemeURI"/>
+                </xsl:call-template>
+                <xsl:if test="$documentation != ''">
+                    <xsl:call-template name="coreLayerDescription">
+                        <xsl:with-param name="definition" select="$documentation"/>
                         <xsl:with-param name="elementUri" select="$conceptSchemeURI"/>
                     </xsl:call-template>
-                    <xsl:if test="$documentation != ''">
-                        <xsl:call-template name="coreLayerDescription">
-                            <xsl:with-param name="definition" select="$documentation"/>
-                            <xsl:with-param name="elementUri" select="$conceptSchemeURI"/>
-                        </xsl:call-template>
-                    </xsl:if>
+                </xsl:if>
 
 
-                    <xsl:call-template name="coreDefinedBy">
+                <xsl:call-template name="coreDefinedBy">
+                    <xsl:with-param name="elementUri" select="$conceptSchemeURI"/>
+                </xsl:call-template>
+
+                <xsl:for-each select="f:getElementTags(.)">
+                    <xsl:call-template name="coreLayerTags">
                         <xsl:with-param name="elementUri" select="$conceptSchemeURI"/>
+                        <xsl:with-param name="tagName" select="./@name"/>
+                        <xsl:with-param name="tagValue" select="./@value"/>
                     </xsl:call-template>
+                </xsl:for-each>
 
-                    <xsl:for-each select="f:getElementTags(.)">
-                        <xsl:call-template name="coreLayerTags">
-                            <xsl:with-param name="elementUri" select="$conceptSchemeURI"/>
-                            <xsl:with-param name="tagName" select="./@name"/>
-                            <xsl:with-param name="tagValue" select="./@value"/>
-                        </xsl:call-template>
-                    </xsl:for-each>
 
-               
+            </xsl:if>
             </xsl:if>
         </xsl:if>
 
@@ -398,6 +408,7 @@
     <xsl:template match="element[@xmi:type = 'uml:Enumeration']/attributes/attribute">
 
         <xsl:if test="$enableGenerationOfSkosConcept">
+            <xsl:if test="not(f:isExcludedByStatus(.))">
             <xsl:variable name="enumerationAttributeName"
                 select="
                     if (boolean(./initial/@body)) then
@@ -414,38 +425,39 @@
                 <xsl:variable name="documentation"
                     select="fn:normalize-space(f:formatDocString(./documentation/@value))"/>
 
- 
 
-                    <skos:Concept rdf:about="{$enumerationAttributeURI}">
-                        <skos:inScheme rdf:resource="{$enumerationURI}"/>
 
-                    </skos:Concept>
+                <skos:Concept rdf:about="{$enumerationAttributeURI}">
+                    <skos:inScheme rdf:resource="{$enumerationURI}"/>
 
-                    <xsl:call-template name="coreLayerName">
-                        <xsl:with-param name="elementName" select="$enumerationAttributeName"/>
+                </skos:Concept>
+
+                <xsl:call-template name="coreLayerName">
+                    <xsl:with-param name="elementName" select="$enumerationAttributeName"/>
+                    <xsl:with-param name="elementUri" select="$enumerationAttributeURI"/>
+                </xsl:call-template>
+                <xsl:if test="$documentation != ''">
+                    <xsl:call-template name="coreLayerDescription">
+                        <xsl:with-param name="definition" select="$documentation"/>
                         <xsl:with-param name="elementUri" select="$enumerationAttributeURI"/>
                     </xsl:call-template>
-                    <xsl:if test="$documentation != ''">
-                        <xsl:call-template name="coreLayerDescription">
-                            <xsl:with-param name="definition" select="$documentation"/>
-                            <xsl:with-param name="elementUri" select="$enumerationAttributeURI"/>
-                        </xsl:call-template>
-                    </xsl:if>
+                </xsl:if>
 
 
-                    <xsl:call-template name="coreDefinedBy">
+                <xsl:call-template name="coreDefinedBy">
+                    <xsl:with-param name="elementUri" select="$enumerationAttributeURI"/>
+                </xsl:call-template>
+
+                <xsl:for-each select="f:getElementTags(.)">
+                    <xsl:call-template name="coreLayerTags">
                         <xsl:with-param name="elementUri" select="$enumerationAttributeURI"/>
+                        <xsl:with-param name="tagName" select="./@name"/>
+                        <xsl:with-param name="tagValue" select="./@value"/>
                     </xsl:call-template>
+                </xsl:for-each>
 
-                    <xsl:for-each select="f:getElementTags(.)">
-                        <xsl:call-template name="coreLayerTags">
-                            <xsl:with-param name="elementUri" select="$enumerationAttributeURI"/>
-                            <xsl:with-param name="tagName" select="./@name"/>
-                            <xsl:with-param name="tagValue" select="./@value"/>
-                        </xsl:call-template>
-                    </xsl:for-each>
-                
 
+            </xsl:if>
             </xsl:if>
         </xsl:if>
     </xsl:template>

--- a/src/owl-core-lib/elements-owl-core.xsl
+++ b/src/owl-core-lib/elements-owl-core.xsl
@@ -36,6 +36,7 @@
             Selector to run core layer transfomation rules for commnents </xd:desc>
     </xd:doc>
     <xsl:template match="ownedComment[@xmi:type = 'uml:Comment']">
+        <xsl:if test="$generateComments">
         <xsl:variable name="commentText" select="./@body"/>
         <xsl:for-each select="./annotatedElement/@xmi:idref">
             <xsl:variable name="elementFound" select="f:getElementByIdRef(., root(.))"/>
@@ -94,6 +95,7 @@
                 </xsl:choose>
             </xsl:if>
         </xsl:for-each>
+        </xsl:if>
     </xsl:template>
 
 

--- a/src/owl-core-lib/elements-owl-core.xsl
+++ b/src/owl-core-lib/elements-owl-core.xsl
@@ -36,7 +36,7 @@
             Selector to run core layer transfomation rules for commnents </xd:desc>
     </xd:doc>
     <xsl:template match="ownedComment[@xmi:type = 'uml:Comment']">
-        <xsl:if test="$generateComments">
+        <xsl:if test="$commentsGeneration">
         <xsl:variable name="commentText" select="./@body"/>
         <xsl:for-each select="./annotatedElement/@xmi:idref">
             <xsl:variable name="elementFound" select="f:getElementByIdRef(., root(.))"/>

--- a/src/reasoning-layer-lib/connectors-reasoning-layer.xsl
+++ b/src/reasoning-layer-lib/connectors-reasoning-layer.xsl
@@ -26,7 +26,7 @@
 
     <xsl:template match="connector[./properties/@ea_type = 'Association']">
         <xsl:variable name="connectorRoleName" select="f:getRoleNameFromConnector(.)"/>
-
+        <xsl:if test="not(f:isExcludedByStatus(.))">
         <xsl:if
             test="
                 ./source/model/@type = 'Class' and ./target/model/@type = 'Class' and
@@ -39,6 +39,7 @@
                 <xsl:with-param name="connector" select="."/>
             </xsl:call-template>
         </xsl:if>
+        </xsl:if>
     </xsl:template>
 
     <xd:doc>
@@ -47,6 +48,7 @@
 
     <xsl:template match="connector[./properties/@ea_type = 'Dependency']">
         <xsl:variable name="connectorRoleName" select="f:getRoleNameFromConnector(.)"/>
+        <xsl:if test="not(f:isExcludedByStatus(.))">
         <xsl:if
             test="
                 ./source/model/@type = 'Class' and ./target/model/@type = 'Class' and
@@ -68,6 +70,7 @@
                 <xsl:with-param name="connector" select="."/>
             </xsl:call-template>
         </xsl:if>
+        </xsl:if>
     </xsl:template>
 
     <xd:doc>
@@ -75,6 +78,7 @@
     </xd:doc>
 
     <xsl:template match="connector[./properties/@ea_type = 'Generalization']">
+        <xsl:if test="not(f:isExcludedByStatus(.))">
         <!--        Filtering for external/internal concepts are inside the functions below due complexity of the functions-->
         <xsl:call-template name="classEquivalence">
             <xsl:with-param name="generalisation" select="."/>
@@ -82,7 +86,7 @@
         <xsl:call-template name="propertiesEquivalence">
             <xsl:with-param name="generalisation" select="."/>
         </xsl:call-template>
-
+        </xsl:if>
 
     </xsl:template>
 
@@ -94,6 +98,7 @@
         <xsl:variable name="generalisations"
             select="//connector[./properties/@ea_type = 'Generalization'][not(target/@xmi:idref = preceding::connector[./properties/@ea_type = 'Generalization']/target/@xmi:idref)]"/>
         <xsl:for-each select="$generalisations">
+            <xsl:if test="not(f:isExcludedByStatus(.))">
             <xsl:if test="./source/model/@type = 'Class' and ./target/model/@type = 'Class'">
                 <!-- Extract prefixes for source and target -->
                 <xsl:variable name="sourcePrefix"
@@ -107,6 +112,7 @@
                         <xsl:with-param name="generalisation" select="."/>
                     </xsl:call-template>
                 </xsl:if>
+            </xsl:if>
             </xsl:if>
         </xsl:for-each>
     </xsl:template>
@@ -122,7 +128,7 @@
         <xsl:variable name="distinctNames" select="f:getDistinctConnectorsNames($root)"/>
         <!--        TODO Figure out dependencies to Objects -->
         <xsl:for-each select="$distinctNames">
-
+            <xsl:if test="not(f:isExcludedByStatus(f:getConnectorByName(., $root)[1]))">
             <xsl:if
                 test="f:getConnectorByName(., $root)[1]/properties/@ea_type = ('Dependency', 'Association') and f:getConnectorByName(., $root)[1]/target/model/@type != 'Object'">
                 <xsl:variable name="connectorElement" select="f:getConnectorByName(., $root)"/>
@@ -142,6 +148,7 @@
                         <xsl:with-param name="root" select="$root"/>
                     </xsl:call-template>
                 </xsl:if>
+            </xsl:if>
             </xsl:if>
         </xsl:for-each>
     </xsl:template>

--- a/src/reasoning-layer-lib/elements-reasoning-layer.xsl
+++ b/src/reasoning-layer-lib/elements-reasoning-layer.xsl
@@ -26,6 +26,7 @@
         <xd:desc>Applying reasoning layer rule to all attributes</xd:desc>
     </xd:doc>
     <xsl:template match="element[@xmi:type = 'uml:Class']/attributes/attribute">
+        <xsl:if test="not(f:isExcludedByStatus(.))">
         <!-- Extract the prefix from the attribute name -->
         <xsl:variable name="attributePrefix" select="fn:substring-before(./@name, ':')"/>
 
@@ -36,6 +37,7 @@
                 <xsl:with-param name="attribute" select="."/>
             </xsl:call-template>
         </xsl:if>
+        </xsl:if>
     </xsl:template>
 
     <xd:doc>
@@ -45,6 +47,7 @@
         <xsl:variable name="root" select="root()"/>
         <xsl:variable name="distinctNames" select="f:getDistinctClassAttributeNames($root)"/>
         <xsl:for-each select="$distinctNames">
+            <xsl:if test="not(f:isExcludedByStatus(f:getClassAttributeByName(., $root)[1]))">
             <!-- Extract the prefix from the attribute name -->
             <xsl:variable name="attributePrefix" select="fn:substring-before(., ':')"/>
 
@@ -63,6 +66,7 @@
                     <xsl:with-param name="attributeName" select="."/>
                     <xsl:with-param name="root" select="$root"/>
                 </xsl:call-template>
+            </xsl:if>
             </xsl:if>
         </xsl:for-each>
     </xsl:template>
@@ -315,6 +319,7 @@
     </xd:doc>
     <xsl:template match="element[@xmi:type = 'uml:Enumeration']">
         <xsl:if test="$enableGenerationOfConceptSchemes">
+            <xsl:if test="not(f:isExcludedByStatus(.))">
             <xsl:variable name="enumerationPrefix" select="fn:substring-before(./@name, ':')"/>
             <!-- Check if the Enumeration should be processed -->
             <xsl:if
@@ -331,6 +336,7 @@
                     <rdfs:subClassOf rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
                 </owl:Class>
             </xsl:if>
+            </xsl:if> 
         </xsl:if>
     </xsl:template>
 

--- a/src/shacl-shape-lib/connectors-shacl-shape.xsl
+++ b/src/shacl-shape-lib/connectors-shacl-shape.xsl
@@ -33,7 +33,7 @@
 
     <xsl:template match="connector[./properties/@ea_type = 'Association']">
         <xsl:variable name="connectorRoleName" select="f:getRoleNameFromConnector(.)"/>
-        
+        <xsl:if test="not(f:isExcludedByStatus(.))">
         <xsl:if
             test="
                 not(./source/model/@type = 'ProxyConnector' or ./target/model/@type = 'ProxyConnector') and (
@@ -53,6 +53,7 @@
                 <xsl:with-param name="connector" select="."/>
             </xsl:call-template>
         </xsl:if>
+        </xsl:if>
     </xsl:template>
 
     <xd:doc>
@@ -61,6 +62,7 @@
 
     <xsl:template match="connector[./properties/@ea_type = 'Dependency']">
         <xsl:variable name="connectorRoleName" select="f:getRoleNameFromConnector(.)"/>
+        <xsl:if test="not(f:isExcludedByStatus(.))">
         <xsl:if
             test="
                 not(./source/model/@type = 'ProxyConnector' or ./target/model/@type = ('ProxyConnector', 'Object')) and (
@@ -89,6 +91,7 @@
             <!--            <xsl:call-template name="connectorAsymmetry">
                 <xsl:with-param name="connector" select="."/>
             </xsl:call-template>-->
+        </xsl:if>
         </xsl:if>
     </xsl:template>
     

--- a/src/shacl-shape-lib/elements-shacl-shape.xsl
+++ b/src/shacl-shape-lib/elements-shacl-shape.xsl
@@ -29,6 +29,7 @@
             Selector to run core layer transfomation rules for commnents </xd:desc>
     </xd:doc>
     <xsl:template match="ownedComment[@xmi:type = 'uml:Comment']">
+        <xsl:if test="$commentsGeneration">
         <xsl:variable name="commentText" select="./@body"/>
         <xsl:for-each select="./annotatedElement/@xmi:idref">
             <xsl:variable name="elementFound" select="f:getElementByIdRef(., root(.))"/>
@@ -91,6 +92,7 @@
                 </xsl:choose>
             </xsl:if>
         </xsl:for-each>
+        </xsl:if>
     </xsl:template>
 
 
@@ -104,6 +106,7 @@
             deterministically generated from the UML Class name. </xd:desc>
     </xd:doc>
     <xsl:template match="element[@xmi:type = 'uml:Class']">
+        <xsl:if test="not(f:isExcludedByStatus(.))">
         <xsl:variable name="class" select="."/>
         <xsl:variable name="className" select="$class/@name"/>
         <xsl:variable name="classNamePrefix" select="fn:substring-before($className, ':')"/>
@@ -143,7 +146,7 @@
 
         </xsl:if>
 
-
+        </xsl:if>
 
         <!--        <xsl:apply-templates select="attributes/attribute"/>-->
 
@@ -155,6 +158,7 @@
         <xd:desc>Applying shape layer rules to attributes</xd:desc>
     </xd:doc>
     <xsl:template match="element[@xmi:type = 'uml:Class']/attributes/attribute">
+        <xsl:if test="not(f:isExcludedByStatus(.))">
         <xsl:variable name="className" select="./../../@name" as="xs:string"/>
         <xsl:variable name="attributePrefix" select="fn:substring-before(./@name, ':')"/>
         <!--        <xsl:variable name="attributeNormalizedLocalName"
@@ -178,6 +182,7 @@
                     <xsl:with-param name="className" select="$className"/>
                 </xsl:call-template>
             </xsl:if>
+        </xsl:if>
         </xsl:if>
     </xsl:template>
 

--- a/test/ePO-default-config/config-parameters.xsl
+++ b/test/ePO-default-config/config-parameters.xsl
@@ -84,6 +84,7 @@
     
     <xsl:variable name="commentsGeneration" select="fn:false()"/>
     <xsl:variable name="commentProperty" select="'skos:editorialNote'"/>
+    <xsl:variable name="generateComments" select="fn:true()"/>
 
     <!-- This variable control if Object and Realisation are generated -->
     <xsl:variable name="generateObjectsAndRealisations" select="fn:false()"/>

--- a/test/ePO-default-config/config-parameters.xsl
+++ b/test/ePO-default-config/config-parameters.xsl
@@ -16,7 +16,6 @@
     </xd:doc>
 
 
-
     <!-- a set of prefix-baseURI definitions -->
     <xsl:variable name="namespacePrefixes" select="fn:doc('namespaces.xml')"/>
 
@@ -82,6 +81,9 @@
     <xsl:variable name="generateReusedConceptsOWLcore" select="fn:true()"/>
     <xsl:variable name="generateReusedConceptsOWLrestrictions" select="fn:true()"/>
     <xsl:variable name="generateReusedConceptsGlossary" select="fn:true()"/>
+    
+    <xsl:variable name="commentsGeneration" select="fn:false()"/>
+    <xsl:variable name="commentProperty" select="'skos:editorialNote'"/>
 
     <!-- This variable control if Object and Realisation are generated -->
     <xsl:variable name="generateObjectsAndRealisations" select="fn:false()"/>

--- a/test/ePO-default-config/config-parameters.xsl
+++ b/test/ePO-default-config/config-parameters.xsl
@@ -84,6 +84,13 @@
     
     <xsl:variable name="commentsGeneration" select="fn:true()"/>
     <xsl:variable name="commentProperty" select="'skos:editorialNote'"/>
+    
+     <!--    Variables for status filtering -->
+    <xsl:variable name="statusProperty" select="'epo:status'"/>
+    <xsl:variable name="validStatusesList" select="('proposed', 'approved', 'implemented')"/>
+    <xsl:variable name="excludedElementStatusesList" select="('proposed', 'approved')"/>
+    <xsl:variable name="unspecifiedStatusInterpretation" select="'implemented'"/>
+    
 
     <!-- This variable control if Object and Realisation are generated -->
     <xsl:variable name="generateObjectsAndRealisations" select="fn:false()"/>

--- a/test/ePO-default-config/config-parameters.xsl
+++ b/test/ePO-default-config/config-parameters.xsl
@@ -82,9 +82,8 @@
     <xsl:variable name="generateReusedConceptsOWLrestrictions" select="fn:true()"/>
     <xsl:variable name="generateReusedConceptsGlossary" select="fn:true()"/>
     
-    <xsl:variable name="commentsGeneration" select="fn:false()"/>
+    <xsl:variable name="commentsGeneration" select="fn:true()"/>
     <xsl:variable name="commentProperty" select="'skos:editorialNote'"/>
-    <xsl:variable name="generateComments" select="fn:false()"/>
 
     <!-- This variable control if Object and Realisation are generated -->
     <xsl:variable name="generateObjectsAndRealisations" select="fn:false()"/>

--- a/test/ePO-default-config/config-parameters.xsl
+++ b/test/ePO-default-config/config-parameters.xsl
@@ -84,7 +84,7 @@
     
     <xsl:variable name="commentsGeneration" select="fn:false()"/>
     <xsl:variable name="commentProperty" select="'skos:editorialNote'"/>
-    <xsl:variable name="generateComments" select="fn:true()"/>
+    <xsl:variable name="generateComments" select="fn:false()"/>
 
     <!-- This variable control if Object and Realisation are generated -->
     <xsl:variable name="generateObjectsAndRealisations" select="fn:false()"/>

--- a/test/ePO-default-config/namespaces.xml
+++ b/test/ePO-default-config/namespaces.xml
@@ -24,6 +24,8 @@
     <prefix name="epo-not" value="http://data.europa.eu/a4g/ontology#"/>
     <prefix name="epo-ord" value="http://data.europa.eu/a4g/ontology#"/>
     <prefix name="epo-sub" value="http://data.europa.eu/a4g/ontology#"/>
+    
+    <prefix name="schema" value="http://schema.org/"/>
 
     <prefix name="nuts" value="http://data.europa.eu/nuts/"/>
     <prefix name="reg2015" value="http://data.europa.eu/a4g/extension/ontology#"/>

--- a/test/unitTests/test-common/test-fetchers.xspec
+++ b/test/unitTests/test-common/test-fetchers.xspec
@@ -279,6 +279,13 @@
         <x:expect label="no tags" select="()"/>
     </x:scenario>
     
+    <x:scenario label="Get connector tags ">
+        <x:call function="f:getConnectorTags">
+            <x:param name="element" href="../../testData/ePO_core_with_tags.xml" select="/xmi:XMI/xmi:Extension[1]/connectors[1]/connector[92]"/>
+        </x:call>
+        <x:expect label="correct tags number" test="count(/tag)=8"/>
+    </x:scenario>
+    
     <x:scenario label="Get connector role name value - Source -> Destination">
         <x:call function="f:getRoleNameFromConnector">
             <x:param name="connector" href="../../testData/ePO-CM-v2.0.1-2020-03-27_test.eap.xmi" select="/xmi:XMI/xmi:Extension[1]/connectors[1]/connector[21]"/>

--- a/test/unitTests/test-common/test-utils.xspec
+++ b/test/unitTests/test-common/test-utils.xspec
@@ -311,7 +311,38 @@
         </x:call>
         <x:expect label="result" select="fn:true()"/>
     </x:scenario>
-
+    
+    <x:scenario label="Scenario for testing filter by status - excluded element">
+        <x:call function="f:isExcludedByStatus">
+            <x:param name="nodeInput"  href="../../testData/ePO-task1-test-status-filtering.xml"
+                select="/xmi:XMI/xmi:Extension[1]/elements[1]/element[168]"/>
+        </x:call>
+        <x:expect label="result" select="fn:true()"/>
+    </x:scenario>
+    
+    <x:scenario label="Scenario for testing filter by status - excluded connector">
+        <x:call function="f:isExcludedByStatus">
+            <x:param name="nodeInput"  href="../../testData/ePO-task1-test-status-filtering.xml"
+                select="/xmi:XMI/xmi:Extension[1]/connectors[1]/connector[648]"/>
+        </x:call>
+        <x:expect label="result" select="fn:true()"/>
+    </x:scenario>
+    
+    <x:scenario label="Scenario for testing filter by status - not excluded element - interpreted status">
+        <x:call function="f:isExcludedByStatus">
+            <x:param name="nodeInput"  href="../../testData/ePO-task1-test-status-filtering.xml"
+                select="/xmi:XMI/xmi:Extension[1]/elements[1]/element[236]"/>
+        </x:call>
+        <x:expect label="result" select="fn:false()"/>
+    </x:scenario>
+    
+    <x:scenario label="Scenario for testing filter by status - not excluded attribute - with implemented status">
+        <x:call function="f:isExcludedByStatus">
+            <x:param name="nodeInput"  href="../../testData/ePO-task1-test-status-filtering.xml"
+                select="/xmi:XMI/xmi:Extension[1]/elements[1]/element[234]/attributes[1]/attribute[2]"/>
+        </x:call>
+        <x:expect label="result" select="fn:false()"/>
+    </x:scenario>
 
     <x:scenario label="Scenario for testing function buildPropertyShapeURI">
         <x:scenario label="valid CURIE">
@@ -354,4 +385,5 @@
                 select="'The function supports only a compact URI'" />
         </x:scenario>
     </x:scenario>
+
 </x:description>

--- a/test/unitTests/test-owl-core-lib/test-descriptors-owl-core.xspec
+++ b/test/unitTests/test-owl-core-lib/test-descriptors-owl-core.xspec
@@ -92,5 +92,51 @@
     </x:scenario>
     
     
+    <x:scenario
+        xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+        xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+        label="Scenario for testing generation of tags - with datatypes - string ">
+        
+        <x:call template="coreLayerTags">
+            <x:param name="tagName" select="'skos:historyNote^^xsd:string'"/>
+            <x:param name="tagValue" select="'Something related with history'"/>
+            <x:param name="elementUri" select="'http://base.onto.uri/ClassName'"/>
+        </x:call>
+        <x:expect label="there is rdf:Description"
+            test="boolean(/rdf:Description[@rdf:about='http://base.onto.uri/ClassName'])"
+        />
+        <x:expect label="correct skos:historyNote text"
+            test="/rdf:Description/skos:historyNote/text() = 'Something related with history'" />
+    </x:scenario>
+    
+
+
+    <x:scenario
+        label="Scenario for testing generation of tags - with URI ">
+        
+        <x:call template="coreLayerTags">
+            <x:param name="tagName" select="'skos:indentifier&lt;&gt;'"/>
+            <x:param name="tagValue" select="'http://base.onto.uri/URI'"/>
+            <x:param name="elementUri" select="'http://base.onto.uri/ClassName'"/>
+        </x:call>
+        <x:expect label="there is rdf:Description"
+            test="boolean(/rdf:Description[@rdf:about='http://base.onto.uri/ClassName'])"
+        />
+        <x:expect label="correct skos:indentifier/@rdf:resource text" test="rdf:Description/skos:indentifier/@rdf:resource = 'http://base.onto.uri/URI'"/>
+    </x:scenario>
+    
+    
+    <x:scenario
+        label="Scenario for testing generation of comments">
+        
+        <x:call template="coreLayerComment">
+            <x:param name="comment" select="'This is a comment'"/>
+            <x:param name="elementUri" select="'http://base.onto.uri/ClassName'"/>
+        </x:call>
+        <x:expect label="there is rdf:Description"
+            test="boolean(/rdf:Description[@rdf:about='http://base.onto.uri/ClassName'])"
+        />
+        <x:expect label="correct skos:editorialNote text" test="rdf:Description/skos:editorialNote/text() = 'This is a comment'"/>
+    </x:scenario>
     
 </x:description>


### PR DESCRIPTION
Issue #226
Status filtering based on the status tag applied by the user within the model.
New config parameters introduced: 

```
<xsl:variable name="statusProperty" select="'epo:status'"/>
<xsl:variable name="validStatusesList" select="('proposed', 'approved', 'implemented')"/>
<xsl:variable name="excludedElementStatusesList" select="('proposed', 'approved')"/>
<xsl:variable name="unspecifiedStatusInterpretation" select="'implemented'"/>

```

Features:

- Configurable status property
- Status value validation within the model using the validStatusesList defined by the user
- Configurable list for excluding elements from the transformation process
- Automatic interpretation of the status for elements without an assigned status in the model