### PR TITLE
T2: Export of controlled vocabulary restrictions #228

### DIFF
--- a/src/common/checkers.xsl
+++ b/src/common/checkers.xsl
@@ -540,6 +540,28 @@
                     $listOfNotDefinedNamespaces"/>
 
     </xsl:function>
+    
+    <xd:doc>
+        <xd:desc>
+            This function checks whether an enumeration has a constraint level property (tag) assigned 
+            and if its value is either "permissive" or "restrictive".
+            
+            The function returns a boolean result:
+            - `true()` if tag exists with the expected property and value.
+            - `false()` if no matching tag is found or if the enumeration has no tags.
+        </xd:desc>
+        <xd:param name="enumeration"/>
+    </xd:doc>
+    <xsl:function name="f:hasEnumerationAConstraintLevelProperty" as="xs:boolean">
+        <xsl:param name="enumeration" as="element()"/>
+        
+        <xsl:variable name="enumerationTags" select="f:getElementTags($enumeration)"/>
+        
+        <xsl:sequence select="
+            some $tag in $enumerationTags
+            satisfies ($tag/@name = $cvConstraintLevelProperty and $tag/@value = ('permissive', 'restrictive'))
+            "/>
+    </xsl:function>
 
 
 

--- a/src/html-conventions-lib/dependency-html-conventions.xsl
+++ b/src/html-conventions-lib/dependency-html-conventions.xsl
@@ -72,9 +72,6 @@
                 <xsl:call-template name="connectorTargetTags">
                     <xsl:with-param name="connector" select="."/>
                 </xsl:call-template>
-                <xsl:call-template name="connectorTags">
-                    <xsl:with-param name="connector" select="."/>
-                </xsl:call-template>
                 <xsl:call-template name="connectorGeneralNameProvided">
                     <xsl:with-param name="connector" select="."/>
                 </xsl:call-template>

--- a/src/html-conventions-lib/enumeration-html-conventions.xsl
+++ b/src/html-conventions-lib/enumeration-html-conventions.xsl
@@ -202,6 +202,30 @@
                 "
         />
     </xsl:template>
+    
+    <xd:doc>
+        <xd:desc>[enumeration-constraint-level-4] he enumeration $value$ does not have a correct constraint level (either permissive or restrictive) set as a tag 
+            with the $cvConstraintLevelProperty$ key. The permissive level will be used as a fallback value. </xd:desc>
+        <xd:param name="enumeration"/>
+    </xd:doc>
+    
+    <xsl:template name="enumerationConstraintLevel">
+        <xsl:param name="enumeration"/>
+        <xsl:sequence
+            select="
+            if (not(f:hasEnumerationAConstraintLevelProperty($enumeration))) then
+            f:generateWarningMessage(fn:concat('The enumeration ', $enumeration/@name,
+            ' does not have a correct constraint level (either permissive or restrictive) set as a tag with the ', $cvConstraintLevelProperty, ' key. The permissive level will be used as a fallback value.'),
+            path($enumeration),
+            'enumeration-constraint-level-4',
+            '',
+            ''
+            )
+            else
+            ()
+            "
+        />
+    </xsl:template>
 
 
    

--- a/src/html-conventions-lib/enumeration-html-conventions.xsl
+++ b/src/html-conventions-lib/enumeration-html-conventions.xsl
@@ -103,6 +103,10 @@
                 <xsl:call-template name="enumerationOutgoingConnectors">
                     <xsl:with-param name="enumeration" select="."/>
                 </xsl:call-template>
+            
+            <xsl:call-template name="enumerationConstraintLevel">
+                <xsl:with-param name="enumeration" select="."/>
+            </xsl:call-template>
                 <!--    End of specific checker rules-->
             
         </xsl:variable>

--- a/src/owl-core-lib/descriptors-owl-core.xsl
+++ b/src/owl-core-lib/descriptors-owl-core.xsl
@@ -99,7 +99,7 @@
         <xsl:param name="tagName"/>
         <xsl:param name="tagValue"/>
         <xsl:param name="elementUri"/>
- <xsl:if test="not($tagName = ($statusProperty, $cvConstraintLevelProperty))">
+        <xsl:if test="not($tagName = $excludedTagNamesList)">
         <rdf:Description rdf:about="{$elementUri}">
         <xsl:choose>
             <xsl:when test="fn:contains($tagName, '@')">

--- a/src/owl-core-lib/descriptors-owl-core.xsl
+++ b/src/owl-core-lib/descriptors-owl-core.xsl
@@ -99,7 +99,7 @@
         <xsl:param name="tagName"/>
         <xsl:param name="tagValue"/>
         <xsl:param name="elementUri"/>
- <xsl:if test="not($tagName = $statusProperty)">
+ <xsl:if test="not($tagName = ($statusProperty, $cvConstraintLevelProperty))">
         <rdf:Description rdf:about="{$elementUri}">
         <xsl:choose>
             <xsl:when test="fn:contains($tagName, '@')">

--- a/src/shacl-shape-lib/elements-shacl-shape.xsl
+++ b/src/shacl-shape-lib/elements-shacl-shape.xsl
@@ -382,7 +382,7 @@
         <!-- Get the enumeration's compact URI -->
         <xsl:variable name="enumerationCompactURI" select="$enumeration/@name"/>
         
-        <xsl:if test="$enumerationCompactURI and $enableGenerationOfConceptSchemes">
+        <xsl:if test="$enumerationCompactURI and $enableGenerationOfSkosConcept">
             <xsl:variable name="shapeURI" select="f:buildPropertyShapeURI($enumerationCompactURI, 'itemShape')"/>
                 <xsl:variable name="inSchemeURI" select="f:buildURIfromLexicalQName($enumerationCompactURI)"/>
                 
@@ -432,7 +432,7 @@
         
         <!-- Generate RDF descriptions based on the constraint level -->
         <xsl:choose>
-            <xsl:when test="$enumerationConstraintLevel = 'restrictive' and $enableGenerationOfConceptSchemes">
+            <xsl:when test="$enumerationConstraintLevel = 'restrictive' and $enableGenerationOfSkosConcept">
                 <!-- Iterate over dependencies -->
 
                     <xsl:variable name="nodeUri" select="f:buildPropertyShapeURI($enumerationCompactURI, 'itemShape')"/>

--- a/src/shacl-shape-lib/elements-shacl-shape.xsl
+++ b/src/shacl-shape-lib/elements-shacl-shape.xsl
@@ -382,14 +382,8 @@
         <!-- Get the enumeration's compact URI -->
         <xsl:variable name="enumerationCompactURI" select="$enumeration/@name"/>
         
-        <!-- Retrieve all attributes -->
-        <xsl:variable name="enumerationItems" select="$enumeration/attributes/attribute"/>
-        
-        <!-- Ensure there are more than one attribute before processing -->
-        <xsl:if test="count($enumerationItems) > 0 and $enumerationCompactURI and $enableGenerationOfConceptSchemes">
-            <xsl:for-each select="$enumerationItems">
-                <xsl:variable name="enumerationItemCompactURI" select="./@name"/>
-                <xsl:variable name="shapeURI" select="f:buildPropertyShapeURI($enumerationCompactURI, $enumerationItemCompactURI)"/>
+        <xsl:if test="$enumerationCompactURI and $enableGenerationOfConceptSchemes">
+            <xsl:variable name="shapeURI" select="f:buildPropertyShapeURI($enumerationCompactURI, 'itemShape')"/>
                 <xsl:variable name="inSchemeURI" select="f:buildURIfromLexicalQName($enumerationCompactURI)"/>
                 
                 <rdf:Description rdf:about="{$shapeURI}">
@@ -399,7 +393,6 @@
                         <sh:hasValue rdf:resource="{$inSchemeURI}"/>
                     </sh:property>
                 </rdf:Description>
-            </xsl:for-each>
         </xsl:if>
     </xsl:template>
     
@@ -433,16 +426,16 @@
             else 'permissive'
             "/>
         
-        <!-- Retrieve all attributes and dependency IDs -->
-        <xsl:variable name="enumerationItems" select="$enumeration/attributes/attribute"/>
+        <!-- Retrieve all dependency IDs -->
+
         <xsl:variable name="dependenciesIds" select="$enumeration/links/Dependency/@xmi:id"/>  
         
         <!-- Generate RDF descriptions based on the constraint level -->
         <xsl:choose>
-            <xsl:when test="$enumerationConstraintLevel = 'restrictive' and fn:count($enumerationItems) > 0 and $enableGenerationOfConceptSchemes">
-                <!-- Iterate over enumeration items and dependencies -->
-                <xsl:for-each select="$enumerationItems">
-                    <xsl:variable name="nodeUri" select="f:buildPropertyShapeURI($enumerationCompactURI, ./@name)"/>
+            <xsl:when test="$enumerationConstraintLevel = 'restrictive' and $enableGenerationOfConceptSchemes">
+                <!-- Iterate over dependencies -->
+
+                    <xsl:variable name="nodeUri" select="f:buildPropertyShapeURI($enumerationCompactURI, 'itemShape')"/>
                     <xsl:for-each select="$dependenciesIds">
                         <xsl:variable name="dependencyConnector" select="f:getConnectorByIdRef(., $root)"/>
                         <xsl:variable name="dependencyName" select="$dependencyConnector/target/role/@name"/>
@@ -456,7 +449,7 @@
                             <sh:node rdf:resource="{$nodeUri}"/>
                         </rdf:Description>
                     </xsl:for-each>
-                </xsl:for-each>
+                
             </xsl:when>
             <xsl:when test="$enumerationConstraintLevel = 'permissive' and $enableGenerationOfSkosConcept">
                 <!-- Generate shapes for permissive or default cases -->

--- a/test/ePO-default-config/config-parameters.xsl
+++ b/test/ePO-default-config/config-parameters.xsl
@@ -88,6 +88,9 @@
     <xsl:variable name="commentsGeneration" select="fn:true()"/>
     <xsl:variable name="commentProperty" select="'skos:editorialNote'"/>
     
+     <!--    Tag names/keys that are excluded from output -->
+    <xsl:variable name="excludedTagNamesList" select="($statusProperty, $cvConstraintLevelProperty)"/>
+    
      <!--    Variables for status filtering -->
     <xsl:variable name="statusProperty" select="'epo:status'"/>
     <xsl:variable name="validStatusesList" select="('proposed', 'approved', 'implemented')"/>

--- a/test/ePO-default-config/config-parameters.xsl
+++ b/test/ePO-default-config/config-parameters.xsl
@@ -70,6 +70,9 @@
     
     <!--    This variable controls whether the enumerations are transformed into skos schemes or ignored-->
     <xsl:variable name="enableGenerationOfConceptSchemes" select="fn:false()"/>
+    
+<!--    Property used for constraint level for enumerations-->
+    <xsl:variable name="cvConstraintLevelProperty" select="'epo:constraintLevel'"/>
 
 
     <!--Allowed characters for a normalized string-->

--- a/test/unitTests/test-common/test-checkers.xspec
+++ b/test/unitTests/test-common/test-checkers.xspec
@@ -491,5 +491,31 @@
         </x:scenario>
     </x:scenario>
     
+    <x:scenario label="testing f:hasEnumerationAConstraintLevelProperty">
+        <x:scenario label="enumeration with no tags">
+            <x:call function="f:hasEnumerationAConstraintLevelProperty">
+                <x:param name="element" href="../../testData/ePO-core-4.2.0.xml" 
+                    select="/xmi:XMI/xmi:Extension[1]/elements[1]/element[259]"/>
+            </x:call>
+            <x:expect label="boolean-false" select="false()"/>
+        </x:scenario>
+        
+        <x:scenario label="enumeration with tag but without constraint level property tag">
+            <x:call function="f:hasEnumerationAConstraintLevelProperty">
+                <x:param name="element" href="../../testData/ePO-core-4.2.0.xml" 
+                    select="/xmi:XMI/xmi:Extension[1]/elements[1]/element[268]"/>
+            </x:call>
+            <x:expect label="boolean-false" select="false()"/>
+        </x:scenario>
+        
+        <x:scenario label="enumeration with correct tag and value">
+            <x:call function="f:hasEnumerationAConstraintLevelProperty">
+                <x:param name="element" href="../../testData/ePO-core-4.2.0.xml" 
+                    select="/xmi:XMI/xmi:Extension[1]/elements[1]/element[245]"/>
+            </x:call>
+            <x:expect label="boolean-true" select="true()"/>
+        </x:scenario>
+    </x:scenario>
+    
 </x:description>
 

--- a/test/unitTests/test-common/test-utils.xspec
+++ b/test/unitTests/test-common/test-utils.xspec
@@ -350,7 +350,7 @@
 
     <x:scenario label="Scenario for testing filter by status - excluded element">
         <x:call function="f:isExcludedByStatus">
-            <x:param name="nodeInput"  href="../../testData/ePO-task1-test-status-filtering.xml"
+            <x:param name="nodeInput"  href="../../testData/ePO-core-4.2.0.xml"
                 select="/xmi:XMI/xmi:Extension[1]/elements[1]/element[168]"/>
         </x:call>
         <x:expect label="result" select="fn:true()"/>
@@ -358,7 +358,7 @@
 
     <x:scenario label="Scenario for testing filter by status - excluded connector">
         <x:call function="f:isExcludedByStatus">
-            <x:param name="nodeInput"  href="../../testData/ePO-task1-test-status-filtering.xml"
+            <x:param name="nodeInput"  href="../../testData/ePO-core-4.2.0.xml"
                 select="/xmi:XMI/xmi:Extension[1]/connectors[1]/connector[648]"/>
         </x:call>
         <x:expect label="result" select="fn:true()"/>
@@ -366,7 +366,7 @@
 
     <x:scenario label="Scenario for testing filter by status - not excluded element - interpreted status">
         <x:call function="f:isExcludedByStatus">
-            <x:param name="nodeInput"  href="../../testData/ePO-task1-test-status-filtering.xml"
+            <x:param name="nodeInput"  href="../../testData/ePO-core-4.2.0.xml"
                 select="/xmi:XMI/xmi:Extension[1]/elements[1]/element[236]"/>
         </x:call>
         <x:expect label="result" select="fn:false()"/>
@@ -374,7 +374,7 @@
 
     <x:scenario label="Scenario for testing filter by status - not excluded attribute - with implemented status">
         <x:call function="f:isExcludedByStatus">
-            <x:param name="nodeInput"  href="../../testData/ePO-task1-test-status-filtering.xml"
+            <x:param name="nodeInput"  href="../../testData/ePO-core-4.2.0.xml"
                 select="/xmi:XMI/xmi:Extension[1]/elements[1]/element[234]/attributes[1]/attribute[2]"/>
         </x:call>
         <x:expect label="result" select="fn:false()"/>

--- a/test/unitTests/test-html-conventions-lib/test-enumeration-html-conventions.xspec
+++ b/test/unitTests/test-html-conventions-lib/test-enumeration-html-conventions.xspec
@@ -75,6 +75,23 @@
         <x:expect label="expect to find a Description Details element" test="boolean(/dd)"/> 
     </x:scenario>
     
+    <x:scenario label="enumeration no constraint level set">
+        <x:call template="enumerationConstraintLevel">
+            <x:param name="enumeration" href="../../testData/ePO-core-4.2.0.xml" 
+                select="/xmi:XMI/xmi:Extension[1]/elements[1]/element[268]"/>
+        </x:call>
+        <x:expect label="expect to find a Description Details element" test="boolean(/dd)"/> 
+        <x:expect label="correct warning text"
+            test="contains(string(/dd), 'The enumeration at-voc:main-activity does not have a correct constraint level (either permissive or restrictive) set as a tag with the epo:constraintLevel key. The permissive level will be used as a fallback value.')"/>
+    </x:scenario>
+    
+    <x:scenario label="enumeration with constraint level set">
+        <x:call template="enumerationConstraintLevel">
+            <x:param name="enumeration" href="../../testData/ePO-core-4.2.0.xml" 
+                select="/xmi:XMI/xmi:Extension[1]/elements[1]/element[245]"/>
+        </x:call>
+        <x:expect label="boolean-true" select="()"/>
+    </x:scenario>
    
     
 </x:description>

--- a/test/unitTests/test-shacl-shape-lib/test-elements-shacl-shape.xspec
+++ b/test/unitTests/test-shacl-shape-lib/test-elements-shacl-shape.xspec
@@ -163,18 +163,24 @@
         <x:call template="enumerationItem">
             <x:param name="enumeration" href="../../testData/ePO-core-4.2.0.xml" select="/xmi:XMI/xmi:Extension[1]/elements[1]/element[244]"/>
         </x:call>   
-        <x:expect label="there is a rdf:Description for each item" test="count(rdf:Description) = 3 "/>
+        <x:expect label="there is a rdf:Description " test="count(rdf:Description) = 1 "/>
         <x:expect label="there is a rdf:type" test="boolean(rdf:Description/rdf:type)"/>
         <x:expect label="there is sh:property" test="boolean(rdf:Description/sh:property)"/>
         <x:expect label="there is sh:path" test="boolean(rdf:Description/sh:property/sh:path)"/>
         <x:expect label="there is sh:hasValue" test="boolean(rdf:Description/sh:property/sh:hasValue)"/>
-        <x:expect label="there is correct value for sh:hasValue resource" test="rdf:Description[1]/sh:property/sh:hasValue/@rdf:resource = 'http://publications.europa.eu/resource/authority/accessibility'"/>
+        <x:expect label="there is correct value for sh:hasValue resource" test="rdf:Description/sh:property/sh:hasValue/@rdf:resource = 'http://publications.europa.eu/resource/authority/accessibility'"/>
     </x:scenario>
         <x:scenario label="enumeration without items">
             <x:call template="enumerationItem">
                 <x:param name="enumeration" href="../../testData/ePO-core-4.2.0.xml" select="/xmi:XMI/xmi:Extension[1]/elements[1]/element[243]"/>
             </x:call>   
-            <x:expect label="there is no output" select="()"/>
+            <x:expect label="there is a rdf:Description " test="count(rdf:Description) = 1 "/>
+            <x:expect label="there is correct value for rdf:about " test="rdf:Description/@rdf:about = 'http://data.europa.eu/a4g/data-shape#at-voc-access-rights-itemShape' "/>
+            <x:expect label="there is a rdf:type" test="boolean(rdf:Description/rdf:type)"/>
+            <x:expect label="there is sh:property" test="boolean(rdf:Description/sh:property)"/>
+            <x:expect label="there is sh:path" test="boolean(rdf:Description/sh:property/sh:path)"/>
+            <x:expect label="there is sh:hasValue" test="boolean(rdf:Description/sh:property/sh:hasValue)"/>
+            <x:expect label="there is correct value for sh:hasValue resource" test="rdf:Description/sh:property/sh:hasValue/@rdf:resource = 'http://publications.europa.eu/resource/authority/access-rights'"/>
         </x:scenario>
         
     </x:scenario>
@@ -207,11 +213,11 @@
             <x:call template="enumerationDependencyRangeShape">
                 <x:param name="enumeration" href="../../testData/ePO-core-4.2.0.xml" select="/xmi:XMI/xmi:Extension[1]/elements[1]/element[250]"/>
             </x:call>   
-            <x:expect label="there is a rdf:Description for each item" test="count(rdf:Description) = 8"/>
+            <x:expect label="there is a rdf:Description for each dependency" test="count(rdf:Description) = 2"/>
             <x:expect label="there is a rdf:type" test="boolean(rdf:Description/rdf:type)"/>
             <x:expect label="there is sh:node" test="boolean(rdf:Description/sh:node)"/>
             <x:expect label="there is sh:path" test="boolean(rdf:Description/sh:path)"/>
-            <x:expect label="there is correct value for sh:node resource" test="rdf:Description[1]/sh:node/@rdf:resource = 'http://data.europa.eu/a4g/data-shape#at-voc-contract-nature-supplies'"/>
+            <x:expect label="there is correct value for sh:node resource" test="rdf:Description[1]/sh:node/@rdf:resource = 'http://data.europa.eu/a4g/data-shape#at-voc-contract-nature-itemShape'"/>
             <x:expect label="there is correct value for sh:path resource" test="rdf:Description[1]/sh:path/@rdf:resource = 'http://data.europa.eu/a4g/ontology#hasContractNatureType'"/>
             <x:expect label="there is correct value for rdf:type resource" test="rdf:Description[1]/rdf:type/@rdf:resource = 'http://www.w3.org/ns/shacl#PropertyShape'"/>
         </x:scenario>
@@ -241,7 +247,13 @@
                     href="../../testData/ePO-core-4.2.0.xml" 
                     select="/xmi:XMI/xmi:Extension[1]/elements[1]/element[280]"/>
             </x:call>   
-            <x:expect label="no output" select="()"/>
+            <x:expect label="there is a rdf:Description for each dependency" test="count(rdf:Description) = 4"/>
+            <x:expect label="there is a rdf:type" test="boolean(rdf:Description/rdf:type)"/>
+            <x:expect label="there is sh:node" test="boolean(rdf:Description/sh:node)"/>
+            <x:expect label="there is sh:path" test="boolean(rdf:Description/sh:path)"/>
+            <x:expect label="there is correct value for sh:node resource" test="rdf:Description[1]/sh:node/@rdf:resource = 'http://data.europa.eu/a4g/data-shape#at-voc-permission-itemShape'"/>
+            <x:expect label="there is correct value for sh:path resource" test="rdf:Description[1]/sh:path/@rdf:resource = 'http://data.europa.eu/a4g/ontology#hasVariantPermission'"/>
+            <x:expect label="there is correct value for rdf:type resource" test="rdf:Description[1]/rdf:type/@rdf:resource = 'http://www.w3.org/ns/shacl#PropertyShape'"/>
         </x:scenario>
         
     </x:scenario>

--- a/test/unitTests/test-shacl-shape-lib/test-elements-shacl-shape.xspec
+++ b/test/unitTests/test-shacl-shape-lib/test-elements-shacl-shape.xspec
@@ -15,6 +15,8 @@
     stylesheet="../../../src/shacl-shape-lib/elements-shacl-shape.xsl">
     
     <x:param name="translatePlainLiteralToStringTypesInSHACL" select="fn:false()"/>
+    <x:param name="enableGenerationOfSkosConcept" select="true()"/>
+    <x:param name="enableGenerationOfConceptSchemes" select="true()"/>
 
     <x:scenario label="Scenario for testing template with match 'element[@xmi:type = 'uml:Class']">
         <x:context href="../../testData/ePO-CM_v.3.0.1.eap.xmi" select="/xmi:XMI/xmi:Extension[1]/elements[1]/element[224]"/>
@@ -154,5 +156,93 @@
         <x:expect label="there is a sh:description" test="boolean(/rdf:Description/sh:description)"/>
         <x:expect label="there is a correct URI" test="/rdf:Description/@rdf:about = 'http://data.europa.eu/a4g/data-shape#epo-LotAwardOutcome-epo-hasAwardedValue'"/>
         <x:expect label="there is a correct URI" test="/rdf:Description[2]/@rdf:about = 'http://data.europa.eu/a4g/data-shape#epo-LotAwardOutcome-epo-hasAwardedEstimatedValue'"/>
+    </x:scenario>
+    
+    <x:scenario label="Scenario for enumerationItem">
+        <x:scenario label="enumeration with items">
+        <x:call template="enumerationItem">
+            <x:param name="enumeration" href="../../testData/ePO-core-4.2.0.xml" select="/xmi:XMI/xmi:Extension[1]/elements[1]/element[244]"/>
+        </x:call>   
+        <x:expect label="there is a rdf:Description for each item" test="count(rdf:Description) = 3 "/>
+        <x:expect label="there is a rdf:type" test="boolean(rdf:Description/rdf:type)"/>
+        <x:expect label="there is sh:property" test="boolean(rdf:Description/sh:property)"/>
+        <x:expect label="there is sh:path" test="boolean(rdf:Description/sh:property/sh:path)"/>
+        <x:expect label="there is sh:hasValue" test="boolean(rdf:Description/sh:property/sh:hasValue)"/>
+        <x:expect label="there is correct value for sh:hasValue resource" test="rdf:Description[1]/sh:property/sh:hasValue/@rdf:resource = 'http://publications.europa.eu/resource/authority/accessibility'"/>
+    </x:scenario>
+        <x:scenario label="enumeration without items">
+            <x:call template="enumerationItem">
+                <x:param name="enumeration" href="../../testData/ePO-core-4.2.0.xml" select="/xmi:XMI/xmi:Extension[1]/elements[1]/element[243]"/>
+            </x:call>   
+            <x:expect label="there is no output" select="()"/>
+        </x:scenario>
+        
+    </x:scenario>
+    
+    <x:scenario label="Scenario for enumerationDependencyRangeShape">
+        <x:scenario label="enumeration with items - permissive">
+            <x:call template="enumerationDependencyRangeShape">
+                <x:param name="enumeration" 
+                    href="../../testData/ePO-core-4.2.0.xml" 
+                    select="/xmi:XMI/xmi:Extension[1]/elements[1]/element[244]"/>
+            </x:call>    
+            <x:expect label="there is an rdf:Description" 
+                test="count(//rdf:Description) = 1"/>
+            <x:expect label="rdf:type is present" 
+                test="boolean(//rdf:Description/rdf:type)"/>
+            <x:expect label="sh:path is present" 
+                test="boolean(//rdf:Description/sh:path)"/>
+            <x:expect label="sh:class is present" 
+                test="boolean(//rdf:Description/sh:class)"/>
+            <x:expect label="correct rdf:about attribute" 
+                test="//rdf:Description/@rdf:about = 'http://data.europa.eu/a4g/data-shape#epo-StrategicProcurement-epo-includesAccessibilityCriterion'"/>
+            <x:expect label="correct rdf:type resource" 
+                test="//rdf:Description/rdf:type/@rdf:resource = 'http://www.w3.org/ns/shacl#PropertyShape'"/>
+            <x:expect label="correct sh:path resource" 
+                test="//rdf:Description/sh:path/@rdf:resource = 'http://data.europa.eu/a4g/ontology#includesAccessibilityCriterion'"/>
+            <x:expect label="correct sh:class resource" 
+                test="//rdf:Description/sh:class/@rdf:resource = 'http://www.w3.org/2004/02/skos/core#Concept'"/>
+        </x:scenario>
+        <x:scenario label="enumeration with items - restrictive ">
+            <x:call template="enumerationDependencyRangeShape">
+                <x:param name="enumeration" href="../../testData/ePO-core-4.2.0.xml" select="/xmi:XMI/xmi:Extension[1]/elements[1]/element[250]"/>
+            </x:call>   
+            <x:expect label="there is a rdf:Description for each item" test="count(rdf:Description) = 8"/>
+            <x:expect label="there is a rdf:type" test="boolean(rdf:Description/rdf:type)"/>
+            <x:expect label="there is sh:node" test="boolean(rdf:Description/sh:node)"/>
+            <x:expect label="there is sh:path" test="boolean(rdf:Description/sh:path)"/>
+            <x:expect label="there is correct value for sh:node resource" test="rdf:Description[1]/sh:node/@rdf:resource = 'http://data.europa.eu/a4g/data-shape#at-voc-contract-nature-supplies'"/>
+            <x:expect label="there is correct value for sh:path resource" test="rdf:Description[1]/sh:path/@rdf:resource = 'http://data.europa.eu/a4g/ontology#hasContractNatureType'"/>
+            <x:expect label="there is correct value for rdf:type resource" test="rdf:Description[1]/rdf:type/@rdf:resource = 'http://www.w3.org/ns/shacl#PropertyShape'"/>
+        </x:scenario>
+        <x:scenario label="enumeration with multiple dependencies and no items - permissive">
+            <x:call template="enumerationDependencyRangeShape">
+                <x:param name="enumeration" 
+                    href="../../testData/ePO-core-4.2.0.xml" 
+                    select="/xmi:XMI/xmi:Extension[1]/elements[1]/element[243]"/>
+            </x:call>   
+            <x:expect label="there are exactly 2 rdf:Description elements" 
+                test="count(//rdf:Description) = 2"/>
+            <x:expect label="correct rdf:about for first description" 
+                test="//rdf:Description[1]/@rdf:about = 'http://data.europa.eu/a4g/data-shape#epo-sub-Response-cccev-confidentialityLevelType'"/>
+            <x:expect label="correct rdf:about for second description" 
+                test="//rdf:Description[2]/@rdf:about = 'http://data.europa.eu/a4g/data-shape#cccev-Evidence-cccev-confidentialityLevelType'"/>
+            <x:expect label="rdf:type exists in both descriptions" 
+                test="count(//rdf:Description/rdf:type) = 2"/>
+            <x:expect label="correct sh:path for both descriptions" 
+                test="count(//rdf:Description[sh:path[@rdf:resource = 'http://data.europa.eu/m8g/confidentialityLevelType']]) = 2"/>
+            <x:expect label="correct sh:class for both descriptions" 
+                test="count(//rdf:Description[sh:class[@rdf:resource = 'http://www.w3.org/2004/02/skos/core#Concept']]) = 2"/>
+        </x:scenario>
+        
+        <x:scenario label="enumeration with no items - restrictive">
+            <x:call template="enumerationDependencyRangeShape">
+                <x:param name="enumeration" 
+                    href="../../testData/ePO-core-4.2.0.xml" 
+                    select="/xmi:XMI/xmi:Extension[1]/elements[1]/element[280]"/>
+            </x:call>   
+            <x:expect label="no output" select="()"/>
+        </x:scenario>
+        
     </x:scenario>
 </x:description>

--- a/test/unitTests/test-shacl-shape-lib/test-elements-shacl-shapes-no-generation-enumerations.xspec
+++ b/test/unitTests/test-shacl-shape-lib/test-elements-shacl-shapes-no-generation-enumerations.xspec
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+    xmlns:fn="http://www.w3.org/2005/xpath-functions"
+    xmlns:uml="http://www.omg.org/spec/UML/20131001"
+    xmlns:xmi="http://www.omg.org/spec/XMI/20131001"
+    xmlns:umldi="http://www.omg.org/spec/UML/20131001/UMLDI"
+    xmlns:dc="http://www.omg.org/spec/UML/20131001/UMLDC" xmlns:owl="http://www.w3.org/2002/07/owl#"
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:dct="http://purl.org/dc/terms/"
+    xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:sh="http://www.w3.org/ns/shacl#"
+    stylesheet="../../../src/shacl-shape-lib/elements-shacl-shape.xsl">
+
+    <x:param name="enableGenerationOfSkosConcept" select="false()"/>
+
+    <x:scenario label="Scenario for enumerationDependencyRangeShape when enableGenerationOfSkosConcept is false">
+        <x:scenario label="enumeration with items - permissive">
+            <x:call template="enumerationDependencyRangeShape">
+                <x:param name="enumeration" href="../../testData/ePO-core-4.2.0.xml"
+                    select="/xmi:XMI/xmi:Extension[1]/elements[1]/element[244]"/>
+            </x:call>
+            <x:expect label="there is no output" select="()"/>
+        </x:scenario>
+        <x:scenario label="enumeration with items - restrictive ">
+            <x:call template="enumerationDependencyRangeShape">
+                <x:param name="enumeration" href="../../testData/ePO-core-4.2.0.xml"
+                    select="/xmi:XMI/xmi:Extension[1]/elements[1]/element[250]"/>
+            </x:call>
+            <x:expect label="there is no output" select="()"/>
+            <x:scenario label="enumeration with multiple dependencies and no items - permissive">
+                <x:call template="enumerationDependencyRangeShape">
+                    <x:param name="enumeration" href="../../testData/ePO-core-4.2.0.xml"
+                        select="/xmi:XMI/xmi:Extension[1]/elements[1]/element[243]"/>
+                </x:call>
+                <x:expect label="there is no output" select="()"/>
+            </x:scenario>
+
+            <x:scenario label="enumeration with no items - restrictive">
+                <x:call template="enumerationDependencyRangeShape">
+                    <x:param name="enumeration" href="../../testData/ePO-core-4.2.0.xml"
+                        select="/xmi:XMI/xmi:Extension[1]/elements[1]/element[280]"/>
+                </x:call>
+                <x:expect label="there is no output" select="()"/>
+            </x:scenario>
+
+        </x:scenario>
+    </x:scenario>
+    
+    <x:scenario label="Scenario for enumerationItem when enableGenerationOfSkosConcept is false">
+        <x:scenario label="enumeration with items">
+            <x:call template="enumerationItem">
+                <x:param name="enumeration" href="../../testData/ePO-core-4.2.0.xml" select="/xmi:XMI/xmi:Extension[1]/elements[1]/element[244]"/>
+            </x:call>   
+            <x:expect label="there is no output" select="()"/> 
+        </x:scenario>
+        <x:scenario label="enumeration without items">
+            <x:call template="enumerationItem">
+                <x:param name="enumeration" href="../../testData/ePO-core-4.2.0.xml" select="/xmi:XMI/xmi:Extension[1]/elements[1]/element[243]"/>
+            </x:call>   
+            <x:expect label="there is no output" select="()"/> 
+        </x:scenario>
+        
+    </x:scenario>
+
+</x:description>


### PR DESCRIPTION
Issue [#228](https://github.com/OP-TED/model2owl/issues/228)

* Added new transformation rules for CVs in the data shape layer

  - Rule R.13. Dependency range shape 
  - Rule D.06. Enumeration item

* Added new convention checker for constraint level of CVs