### PR TITLE
removed enableGenerationOfConceptSchemes filter from CVs SHACL rules

### DIFF
--- a/src/shacl-shape-lib/elements-shacl-shape.xsl
+++ b/src/shacl-shape-lib/elements-shacl-shape.xsl
@@ -382,7 +382,17 @@
         <!-- Get the enumeration's compact URI -->
         <xsl:variable name="enumerationCompactURI" select="$enumeration/@name"/>
         
-        <xsl:if test="$enumerationCompactURI and $enableGenerationOfConceptSchemes">
+        <xsl:variable name="enumerationTags" select="f:getElementTags($enumeration)"/>
+        
+        <!-- Determine the constraint level, defaulting to 'permissive' -->
+        <xsl:variable name="enumerationConstraintLevel" 
+            select="
+            if (some $tag in $enumerationTags satisfies $tag/@name = $cvConstraintLevelProperty)
+            then ($enumerationTags[@name = $cvConstraintLevelProperty][1]/@value)
+            else 'permissive'
+            "/>
+        
+        <xsl:if test="$enumerationCompactURI and $enumerationConstraintLevel = 'restrictive'">
             <xsl:variable name="shapeURI" select="f:buildPropertyShapeURI($enumerationCompactURI, 'itemShape')"/>
                 <xsl:variable name="inSchemeURI" select="f:buildURIfromLexicalQName($enumerationCompactURI)"/>
                 
@@ -432,7 +442,7 @@
         
         <!-- Generate RDF descriptions based on the constraint level -->
         <xsl:choose>
-            <xsl:when test="$enumerationConstraintLevel = 'restrictive' and $enableGenerationOfConceptSchemes">
+            <xsl:when test="$enumerationConstraintLevel = 'restrictive'">
                 <!-- Iterate over dependencies -->
 
                     <xsl:variable name="nodeUri" select="f:buildPropertyShapeURI($enumerationCompactURI, 'itemShape')"/>
@@ -451,7 +461,7 @@
                     </xsl:for-each>
                 
             </xsl:when>
-            <xsl:when test="$enumerationConstraintLevel = 'permissive' and $enableGenerationOfConceptSchemes">
+            <xsl:when test="$enumerationConstraintLevel = 'permissive'">
                 <!-- Generate shapes for permissive or default cases -->
                 <xsl:for-each select="$dependenciesIds">
                     <xsl:variable name="dependencyConnector" select="f:getConnectorByIdRef(., $root)"/>

--- a/test/unitTests/test-shacl-shape-lib/test-elements-shacl-shape.xspec
+++ b/test/unitTests/test-shacl-shape-lib/test-elements-shacl-shape.xspec
@@ -159,28 +159,37 @@
     </x:scenario>
     
     <x:scenario label="Scenario for enumerationItem">
-        <x:scenario label="enumeration with items">
+        <x:scenario label="enumeration with items - restrictive">
         <x:call template="enumerationItem">
-            <x:param name="enumeration" href="../../testData/ePO-core-4.2.0.xml" select="/xmi:XMI/xmi:Extension[1]/elements[1]/element[244]"/>
+            <x:param name="enumeration" href="../../testData/ePO-core-4.2.0.xml" select="/xmi:XMI/xmi:Extension[1]/elements[1]/element[250]"/>
         </x:call>   
         <x:expect label="there is a rdf:Description " test="count(rdf:Description) = 1 "/>
         <x:expect label="there is a rdf:type" test="boolean(rdf:Description/rdf:type)"/>
         <x:expect label="there is sh:property" test="boolean(rdf:Description/sh:property)"/>
         <x:expect label="there is sh:path" test="boolean(rdf:Description/sh:property/sh:path)"/>
         <x:expect label="there is sh:hasValue" test="boolean(rdf:Description/sh:property/sh:hasValue)"/>
-        <x:expect label="there is correct value for sh:hasValue resource" test="rdf:Description/sh:property/sh:hasValue/@rdf:resource = 'http://publications.europa.eu/resource/authority/accessibility'"/>
+            <x:expect label="there is correct value for sh:hasValue resource" test="rdf:Description/sh:property/sh:hasValue/@rdf:resource = 'http://publications.europa.eu/resource/authority/contract-nature'"/>
     </x:scenario>
-        <x:scenario label="enumeration without items">
+        
+
+        <x:scenario label="enumeration without items - restrictive">
+                <x:call template="enumerationItem">
+                    <x:param name="enumeration" href="../../testData/ePO-core-4.2.0.xml" select="/xmi:XMI/xmi:Extension[1]/elements[1]/element[280]"/>
+                </x:call>   
+                <x:expect label="there is a rdf:Description " test="count(rdf:Description) = 1 "/>
+                <x:expect label="there is a rdf:type" test="boolean(rdf:Description/rdf:type)"/>
+                <x:expect label="there is sh:property" test="boolean(rdf:Description/sh:property)"/>
+                <x:expect label="there is sh:path" test="boolean(rdf:Description/sh:property/sh:path)"/>
+                <x:expect label="there is sh:hasValue" test="boolean(rdf:Description/sh:property/sh:hasValue)"/>
+            <x:expect label="there is correct value for sh:hasValue resource" test="rdf:Description/sh:property/sh:hasValue/@rdf:resource = 'http://publications.europa.eu/resource/authority/permission'"/>
+            </x:scenario>
+        
+        
+        <x:scenario label="enumeration without items - permissive">
             <x:call template="enumerationItem">
                 <x:param name="enumeration" href="../../testData/ePO-core-4.2.0.xml" select="/xmi:XMI/xmi:Extension[1]/elements[1]/element[243]"/>
             </x:call>   
-            <x:expect label="there is a rdf:Description " test="count(rdf:Description) = 1 "/>
-            <x:expect label="there is correct value for rdf:about " test="rdf:Description/@rdf:about = 'http://data.europa.eu/a4g/data-shape#at-voc-access-rights-itemShape' "/>
-            <x:expect label="there is a rdf:type" test="boolean(rdf:Description/rdf:type)"/>
-            <x:expect label="there is sh:property" test="boolean(rdf:Description/sh:property)"/>
-            <x:expect label="there is sh:path" test="boolean(rdf:Description/sh:property/sh:path)"/>
-            <x:expect label="there is sh:hasValue" test="boolean(rdf:Description/sh:property/sh:hasValue)"/>
-            <x:expect label="there is correct value for sh:hasValue resource" test="rdf:Description/sh:property/sh:hasValue/@rdf:resource = 'http://publications.europa.eu/resource/authority/access-rights'"/>
+            <x:expect label="there is no output" select="()"/>
         </x:scenario>
         
     </x:scenario>

--- a/test/unitTests/test-shacl-shape-lib/test-elements-shacl-shapes-no-generation-enumerations.xspec
+++ b/test/unitTests/test-shacl-shape-lib/test-elements-shacl-shapes-no-generation-enumerations.xspec
@@ -12,51 +12,103 @@
 
     <x:param name="enableGenerationOfConceptSchemes" select="false()"/>
 
-    <x:scenario label="Scenario for enumerationDependencyRangeShape when enableGenerationOfSkosConcept is false">
+    <x:scenario label="Scenario for enumerationDependencyRangeShape when enableGenerationOfConceptSchemes is false">
         <x:scenario label="enumeration with items - permissive">
             <x:call template="enumerationDependencyRangeShape">
-                <x:param name="enumeration" href="../../testData/ePO-core-4.2.0.xml"
+                <x:param name="enumeration" 
+                    href="../../testData/ePO-core-4.2.0.xml" 
                     select="/xmi:XMI/xmi:Extension[1]/elements[1]/element[244]"/>
-            </x:call>
-            <x:expect label="there is no output" select="()"/>
+            </x:call>    
+            <x:expect label="there is an rdf:Description" 
+                test="count(//rdf:Description) = 1"/>
+            <x:expect label="rdf:type is present" 
+                test="boolean(//rdf:Description/rdf:type)"/>
+            <x:expect label="sh:path is present" 
+                test="boolean(//rdf:Description/sh:path)"/>
+            <x:expect label="sh:class is present" 
+                test="boolean(//rdf:Description/sh:class)"/>
+            <x:expect label="correct rdf:about attribute" 
+                test="//rdf:Description/@rdf:about = 'http://data.europa.eu/a4g/data-shape#epo-StrategicProcurement-epo-includesAccessibilityCriterion'"/>
+            <x:expect label="correct rdf:type resource" 
+                test="//rdf:Description/rdf:type/@rdf:resource = 'http://www.w3.org/ns/shacl#PropertyShape'"/>
+            <x:expect label="correct sh:path resource" 
+                test="//rdf:Description/sh:path/@rdf:resource = 'http://data.europa.eu/a4g/ontology#includesAccessibilityCriterion'"/>
+            <x:expect label="correct sh:class resource" 
+                test="//rdf:Description/sh:class/@rdf:resource = 'http://www.w3.org/2004/02/skos/core#Concept'"/>
         </x:scenario>
         <x:scenario label="enumeration with items - restrictive ">
             <x:call template="enumerationDependencyRangeShape">
-                <x:param name="enumeration" href="../../testData/ePO-core-4.2.0.xml"
-                    select="/xmi:XMI/xmi:Extension[1]/elements[1]/element[250]"/>
-            </x:call>
-            <x:expect label="there is no output" select="()"/>
-            <x:scenario label="enumeration with multiple dependencies and no items - permissive">
-                <x:call template="enumerationDependencyRangeShape">
-                    <x:param name="enumeration" href="../../testData/ePO-core-4.2.0.xml"
-                        select="/xmi:XMI/xmi:Extension[1]/elements[1]/element[243]"/>
-                </x:call>
-                <x:expect label="there is no output" select="()"/>
-            </x:scenario>
-
-            <x:scenario label="enumeration with no items - restrictive">
-                <x:call template="enumerationDependencyRangeShape">
-                    <x:param name="enumeration" href="../../testData/ePO-core-4.2.0.xml"
-                        select="/xmi:XMI/xmi:Extension[1]/elements[1]/element[280]"/>
-                </x:call>
-                <x:expect label="there is no output" select="()"/>
-            </x:scenario>
-
+                <x:param name="enumeration" href="../../testData/ePO-core-4.2.0.xml" select="/xmi:XMI/xmi:Extension[1]/elements[1]/element[250]"/>
+            </x:call>   
+            <x:expect label="there is a rdf:Description for each dependency" test="count(rdf:Description) = 2"/>
+            <x:expect label="there is a rdf:type" test="boolean(rdf:Description/rdf:type)"/>
+            <x:expect label="there is sh:node" test="boolean(rdf:Description/sh:node)"/>
+            <x:expect label="there is sh:path" test="boolean(rdf:Description/sh:path)"/>
+            <x:expect label="there is correct value for sh:node resource" test="rdf:Description[1]/sh:node/@rdf:resource = 'http://data.europa.eu/a4g/data-shape#at-voc-contract-nature-itemShape'"/>
+            <x:expect label="there is correct value for sh:path resource" test="rdf:Description[1]/sh:path/@rdf:resource = 'http://data.europa.eu/a4g/ontology#hasContractNatureType'"/>
+            <x:expect label="there is correct value for rdf:type resource" test="rdf:Description[1]/rdf:type/@rdf:resource = 'http://www.w3.org/ns/shacl#PropertyShape'"/>
         </x:scenario>
+        <x:scenario label="enumeration with multiple dependencies and no items - permissive">
+            <x:call template="enumerationDependencyRangeShape">
+                <x:param name="enumeration" 
+                    href="../../testData/ePO-core-4.2.0.xml" 
+                    select="/xmi:XMI/xmi:Extension[1]/elements[1]/element[243]"/>
+            </x:call>   
+            <x:expect label="there are exactly 2 rdf:Description elements" 
+                test="count(//rdf:Description) = 2"/>
+            <x:expect label="correct rdf:about for first description" 
+                test="//rdf:Description[1]/@rdf:about = 'http://data.europa.eu/a4g/data-shape#epo-sub-Response-cccev-confidentialityLevelType'"/>
+            <x:expect label="correct rdf:about for second description" 
+                test="//rdf:Description[2]/@rdf:about = 'http://data.europa.eu/a4g/data-shape#cccev-Evidence-cccev-confidentialityLevelType'"/>
+            <x:expect label="rdf:type exists in both descriptions" 
+                test="count(//rdf:Description/rdf:type) = 2"/>
+            <x:expect label="correct sh:path for both descriptions" 
+                test="count(//rdf:Description[sh:path[@rdf:resource = 'http://data.europa.eu/m8g/confidentialityLevelType']]) = 2"/>
+            <x:expect label="correct sh:class for both descriptions" 
+                test="count(//rdf:Description[sh:class[@rdf:resource = 'http://www.w3.org/2004/02/skos/core#Concept']]) = 2"/>
+        </x:scenario>
+        
+        <x:scenario label="enumeration with no items - restrictive">
+            <x:call template="enumerationDependencyRangeShape">
+                <x:param name="enumeration" 
+                    href="../../testData/ePO-core-4.2.0.xml" 
+                    select="/xmi:XMI/xmi:Extension[1]/elements[1]/element[280]"/>
+            </x:call>   
+            <x:expect label="there is a rdf:Description for each dependency" test="count(rdf:Description) = 4"/>
+            <x:expect label="there is a rdf:type" test="boolean(rdf:Description/rdf:type)"/>
+            <x:expect label="there is sh:node" test="boolean(rdf:Description/sh:node)"/>
+            <x:expect label="there is sh:path" test="boolean(rdf:Description/sh:path)"/>
+            <x:expect label="there is correct value for sh:node resource" test="rdf:Description[1]/sh:node/@rdf:resource = 'http://data.europa.eu/a4g/data-shape#at-voc-permission-itemShape'"/>
+            <x:expect label="there is correct value for sh:path resource" test="rdf:Description[1]/sh:path/@rdf:resource = 'http://data.europa.eu/a4g/ontology#hasVariantPermission'"/>
+            <x:expect label="there is correct value for rdf:type resource" test="rdf:Description[1]/rdf:type/@rdf:resource = 'http://www.w3.org/ns/shacl#PropertyShape'"/>
+        </x:scenario>
+
     </x:scenario>
     
-    <x:scenario label="Scenario for enumerationItem when enableGenerationOfSkosConcept is false">
-        <x:scenario label="enumeration with items">
+    <x:scenario label="Scenario for enumerationItem when enableGenerationOfConceptSchemes is false">
+        <x:scenario label="enumeration with items permissive">
             <x:call template="enumerationItem">
                 <x:param name="enumeration" href="../../testData/ePO-core-4.2.0.xml" select="/xmi:XMI/xmi:Extension[1]/elements[1]/element[244]"/>
             </x:call>   
             <x:expect label="there is no output" select="()"/> 
         </x:scenario>
-        <x:scenario label="enumeration without items">
+        <x:scenario label="enumeration without items permissive">
             <x:call template="enumerationItem">
                 <x:param name="enumeration" href="../../testData/ePO-core-4.2.0.xml" select="/xmi:XMI/xmi:Extension[1]/elements[1]/element[243]"/>
             </x:call>   
             <x:expect label="there is no output" select="()"/> 
+        </x:scenario>
+        
+        <x:scenario label="enumeration with items - restrictive">
+            <x:call template="enumerationItem">
+                <x:param name="enumeration" href="../../testData/ePO-core-4.2.0.xml" select="/xmi:XMI/xmi:Extension[1]/elements[1]/element[250]"/>
+            </x:call>   
+            <x:expect label="there is a rdf:Description " test="count(rdf:Description) = 1 "/>
+            <x:expect label="there is a rdf:type" test="boolean(rdf:Description/rdf:type)"/>
+            <x:expect label="there is sh:property" test="boolean(rdf:Description/sh:property)"/>
+            <x:expect label="there is sh:path" test="boolean(rdf:Description/sh:property/sh:path)"/>
+            <x:expect label="there is sh:hasValue" test="boolean(rdf:Description/sh:property/sh:hasValue)"/>
+            <x:expect label="there is correct value for sh:hasValue resource" test="rdf:Description/sh:property/sh:hasValue/@rdf:resource = 'http://publications.europa.eu/resource/authority/contract-nature'"/>
         </x:scenario>
         
     </x:scenario>


### PR DESCRIPTION
* removed enableGenerationOfConceptSchemes filter from CVs SHACL rules
* updated Rule D.06. Enumeration item to generate output only for restrictive level