### PR TITLE
Disable filtering of external terms for attributes and relationships

### DIFF
--- a/src/reasoning-layer-lib/connectors-reasoning-layer.xsl
+++ b/src/reasoning-layer-lib/connectors-reasoning-layer.xsl
@@ -25,13 +25,9 @@
     </xd:doc>
 
     <xsl:template match="connector[./properties/@ea_type = 'Association']">
-        <xsl:variable name="connectorRoleName" select="f:getRoleNameFromConnector(.)"/>
         <xsl:if test="not(f:isExcludedByStatus(.))">
         <xsl:if
-            test="
-                ./source/model/@type = 'Class' and ./target/model/@type = 'Class' and
-                ($generateReusedConceptsOWLrestrictions or
-                fn:substring-before($connectorRoleName, ':') = $includedPrefixesList)">
+            test="./source/model/@type = 'Class' and ./target/model/@type = 'Class'">
             <xsl:call-template name="connectorMultiplicity">
                 <xsl:with-param name="connector" select="."/>
             </xsl:call-template>

--- a/src/reasoning-layer-lib/elements-reasoning-layer.xsl
+++ b/src/reasoning-layer-lib/elements-reasoning-layer.xsl
@@ -27,16 +27,9 @@
     </xd:doc>
     <xsl:template match="element[@xmi:type = 'uml:Class']/attributes/attribute">
         <xsl:if test="not(f:isExcludedByStatus(.))">
-        <!-- Extract the prefix from the attribute name -->
-        <xsl:variable name="attributePrefix" select="fn:substring-before(./@name, ':')"/>
-
-        <!-- Check if the attribute should be processed -->
-        <xsl:if
-            test="$generateReusedConceptsOWLrestrictions or $attributePrefix = $includedPrefixesList">
             <xsl:call-template name="attributeMultiplicity">
                 <xsl:with-param name="attribute" select="."/>
             </xsl:call-template>
-        </xsl:if>
         </xsl:if>
     </xsl:template>
 

--- a/test/unitTests/test-reasoning-layer-lib/test-connectors-reasoning-layer-wo-reused-concepts.xspec
+++ b/test/unitTests/test-reasoning-layer-lib/test-connectors-reasoning-layer-wo-reused-concepts.xspec
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description
+    xmlns:x="http://www.jenitennison.com/xslt/xspec"
+    xmlns:uml="http://www.omg.org/spec/UML/20131001"
+    xmlns:xmi="http://www.omg.org/spec/XMI/20131001"
+    xmlns:umldi="http://www.omg.org/spec/UML/20131001/UMLDI"
+    xmlns:dc="http://www.omg.org/spec/UML/20131001/UMLDC" 
+    xmlns:owl="http://www.w3.org/2002/07/owl#"
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" 
+    xmlns:dct="http://purl.org/dc/terms/"
+    xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+    xmlns:sh="http://www.w3.org/ns/shacl#"
+    stylesheet="../../../src/reasoning-layer-lib/connectors-reasoning-layer.xsl">
+    
+    <x:param name="generateReusedConceptsOWLrestrictions" select="false()"/>
+
+    <x:scenario label="Test connector[./properties/@ea_type = 'Association'] - for disabled generateReusedConceptsOWLrestrictions">
+        <x:context href="../../testData/ePO-core-4.2.0.xml" select="/"/>
+        <x:variable name="testedPropUri"
+            as="xs:string"
+            select="'http://www.w3.org/ns/adms#identifier'"/>
+        <x:expect label="restriction on property set" test="/rdf:Description[@rdf:about='http://data.europa.eu/m8g/InformationConcept']/rdfs:subClassOf/owl:Restriction/owl:onProperty/@rdf:resource = $testedPropUri"/>
+    </x:scenario>
+  
+</x:description>

--- a/test/unitTests/test-reasoning-layer-lib/test-elements-reasoning-layer.xspec
+++ b/test/unitTests/test-reasoning-layer-lib/test-elements-reasoning-layer.xspec
@@ -181,4 +181,14 @@
     </x:scenario>
     
 
+    <x:param name="generateReusedConceptsOWLrestrictions" select="false()"/>
+
+    <x:scenario label="Test element[@xmi:type = 'uml:Class']/attributes/attribute - for disabled generateReusedConceptsOWLrestrictions">
+        <x:context href="../../testData/ePO-core-4.2.0.xml" select="/xmi:XMI/xmi:Extension[1]/elements[1]/element[133]/attributes[1]/attribute[2]"/>
+        <x:variable name="testedPropUri"
+            as="xs:string"
+            select="'http://purl.org/dc/terms/issued'"/>
+        <x:expect label="restriction on property set" test="/rdf:Description[@rdf:about='http://data.europa.eu/a4g/ontology#Document']/rdfs:subClassOf/owl:Restriction/owl:onProperty/@rdf:resource = $testedPropUri"/>
+    </x:scenario>
+
 </x:description>


### PR DESCRIPTION
The change fixes a bug causing some statements involving external terms to be filtered out. Terms that are referenced (not defined) should be included in generated OWL restrictions artefact regardless of their origin.

Changes:
* Fixed implementation
* New tests demonstrating the fix (for attribute and object property: `dct:issued` and `adms:identifier`)