### PR TITLE
Update the source of the Saxon JAR file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ get-saxon: saxon/saxon.jar
 saxon/saxon.jar:
 	@echo Installing saxon
 	mkdir -p saxon
-	cd saxon  && curl -L -o saxon.zip "https://kumisystems.dl.sourceforge.net/project/saxon/Saxon-HE/10/Java/SaxonHE10-6J.zip" && unzip saxon.zip && rm -rf saxon.zip
+	cd saxon  && curl -L -o saxon.zip "https://sourceforge.net/projects/saxon/files/Saxon-HE/10/Java/SaxonHE10-6J.zip" && unzip saxon.zip && rm -rf saxon.zip
 	cd saxon && mv saxon-he-10.6.jar saxon.jar
 	@echo 'Saxon path is saxon/saxon.jar'
 


### PR DESCRIPTION
The former URL became obsolete. The change sets an updated working URL for the used executable.