### PR TITLE
Make the ReSpec package generation logic generic and extendable (TEDM2O-11)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,20 +45,13 @@ RDF_XML_MIME_TYPE:='application/rdf+xml'
 TURTLE_MIME_TYPE:='turtle'
 JSONLD_CONTEXT_INDENTATION?=2
 
-# default locations for artefacts and other resource files
-OWL_CORE_FILE_PATH?=${OUTPUT_FOLDER_PATH}/${XMI_INPUT_FILENAME_WITHOUT_EXTENSION}.rdf
-OWL_RESTR_FILE_PATH?=${OUTPUT_FOLDER_PATH}/${XMI_INPUT_FILENAME_WITHOUT_EXTENSION}_restrictions.rdf
-SHACL_SHAPES_FILE_PATH?=${OUTPUT_FOLDER_PATH}/${XMI_INPUT_FILENAME_WITHOUT_EXTENSION}_shapes.rdf
-JSONLD_CONTEXT_FILE_PATH?=${OUTPUT_FOLDER_PATH}/${XMI_INPUT_FILENAME_WITHOUT_EXTENSION}_context.jsonld
-MODEL_XMI_FILE_PATH?=${ABSOLUTE_MODEL2OWL_FOLDER}/test/testData/ePO-core-4.2.0.xml
-MODEL_EAP_FILE_PATH?=
-
 # respec variables with default values
 RESPEC_JSON_INDENTATION?=2
 RESPEC_DATA_JSON_PATH?=${OUTPUT_FOLDER_PATH}/${XMI_INPUT_FILENAME_WITHOUT_EXTENSION}_respec.json
 RESPEC_METADATA_JSON_PATH?=${ABSOLUTE_MODEL2OWL_FOLDER}/test/ePO-default-config/metadata.json
 RESPEC_INPUT_ASSETS_DIR=${ABSOLUTE_MODEL2OWL_FOLDER}/respec-resources/assets
-SDS_FILES_JSON_LOCATION=.assets.sdsSection
+INPUT_SDS_FILES_JSON_LOCATION=.metadata.projectLocalResources
+TARGET_SDS_FILES_JSON_LOCATION=.assets.sdsSection
 RESPEC_OUTPUT_DIR?=${OUTPUT_FOLDER_PATH}/respec
 RESPEC_SDS_OUTPUT_DIR=${RESPEC_OUTPUT_DIR}/sds
 
@@ -398,29 +391,16 @@ convert-rdf-to-rdf:
 #	[RESPEC_METADATA_JSON_PATH=/path/to/metadata.json]
 #	[RESPEC_INPUT_ASSETS_DIR=/path/to/static/assets]
 #	[XMI_INPUT_FILE_PATH=/path/to/model.xmi]
-#	[MODEL_EAP_FILE_PATH=/path/to/model.eap]
 #	[OUTPUT_FOLDER_PATH=/path/to/generated/model2owl/artefacts]
-#	[OWL_CORE_FILE_PATH=/path/to/owl-core.rdf]
-#	[OWL_RESTR_FILE_PATH=/path/to/owl-restrictions.rdf]
-#	[SHACL_SHAPES_FILE_PATH=/path/to/shacl-shapes.rdf]
-#	[JSONLD_CONTEXT_FILE_PATH=/path/to/jsonld-context.jsonld]
 # where:
 #   RESPEC_OUTPUT_DIR: Output directory for the documentation package.
 #   RESPEC_DATA_JSON_PATH: (Optional) Path to the ReSpec data JSON file.
 #   RESPEC_METADATA_JSON_PATH: Path to the metadata JSON file.
 #   RESPEC_INPUT_ASSETS_DIR: Directory containing static assets (images, examples, etc.).
-#   XMI_INPUT_FILE_PATH: Path to the UML XMI model file.
-#   MODEL_EAP_FILE_PATH: Path to the UML EAP model file.
-#   OUTPUT_FOLDER_PATH: Directory containing generated model2owl artefacts.
-#   OWL_CORE_FILE_PATH: Path to the generated OWL core file.
-#   OWL_RESTR_FILE_PATH: Path to the generated OWL restrictions file.
-#   SHACL_SHAPES_FILE_PATH: Path to the generated SHACL shapes file.
-#   JSONLD_CONTEXT_FILE_PATH: Path to the generated JSON-LD context file.
-#
-# If OUTPUT_FOLDER_PATH is given then OWL_CORE_FILE_PATH, OWL_RESTR_FILE_PATH,
-# SHACL_SHAPES_FILE_PATH, and JSONLD_CONTEXT_FILE_PATH can be skipped if the
-# file names follow the default naming convention and are located in
-# OUTPUT_FOLDER_PATH.
+#   XMI_INPUT_FILE_PATH: (Optional) Path to the UML XMI model file needed for
+#						 generating the ReSpec data JSON file (if not given).
+#   OUTPUT_FOLDER_PATH: (Optional) Directory where a ReSpec data JSON file 
+#						should be stored (if not given).
 generate-respec:
 	@## Add a key-value artefact entry to the metadata JSON file. \
 	extend_metadata_json() { \
@@ -428,11 +408,11 @@ generate-respec:
 		local key="$$2"; \
 		local value="$$3"; \
 		tmp=$$(mktemp --suffix=".json"); \
-		$(JQ) --arg k "$$key" --arg v "$$value" '${SDS_FILES_JSON_LOCATION} += [{"name": $$k, "path": $$v}]' "$$json_file" > $$tmp && mv $$tmp "$$json_file"; \
+		$(JQ) --arg k "$$key" --arg v "$$value" '${TARGET_SDS_FILES_JSON_LOCATION} += [{"name": $$k, "path": $$v}]' "$$json_file" > $$tmp && mv $$tmp "$$json_file"; \
 		rm -f $$tmp; \
 	}; \
 	\
-	## Copy artefact to output ReSpec directory and records its relative path in metadata JSON. \
+	## Copy artefact to target ReSpec directory and records its relative path in metadata JSON. \
 	handle_artefact_file() { \
 		local json_file="$$1"; \
 		local artefact_name="$$2"; \
@@ -454,15 +434,21 @@ generate-respec:
 	\
 	mkdir -p ${RESPEC_SDS_OUTPUT_DIR}; \
 	\
-	# Copy any provided artefacts and log them in the metadata JSON \
+	# Copy any provided artefacts to the target directory and update file paths in the metadata JSON \
 	ext_md_json=$$(mktemp --suffix=".json"); \
 	cp -f ${RESPEC_METADATA_JSON_PATH} $$ext_md_json; \
-	handle_artefact_file $$ext_md_json "OWL core file" "${OWL_CORE_FILE_PATH}" ; \
-	handle_artefact_file $$ext_md_json "OWL restrictions file" "${OWL_RESTR_FILE_PATH}" ; \
-	handle_artefact_file $$ext_md_json "SHACL shapes file" "${SHACL_SHAPES_FILE_PATH}" ; \
-	handle_artefact_file $$ext_md_json "JSON-LD context file" "${JSONLD_CONTEXT_FILE_PATH}" ; \
-	handle_artefact_file $$ext_md_json "UML XMI model file" "${XMI_INPUT_FILE_PATH}" ; \
-	handle_artefact_file $$ext_md_json "UML EAP model file" "${MODEL_EAP_FILE_PATH}" ; \
+	# Loop over each object in projectLocalResources \
+	jq -c '${INPUT_SDS_FILES_JSON_LOCATION}[]' $$ext_md_json | while read -r item; do \
+		# Extract name and path \
+		name=$$(echo "$$item" | jq -r '.name') ; \
+		path=$$(echo "$$item" | jq -r '.path') ; \
+		\
+		handle_artefact_file $$ext_md_json "$$name" "$$path" ; \
+	done ; \
+	\
+	# remove any existing projectLocalResources entry as it is no longer needed in the working metadata JSON \
+	ext_md_json_updated=$$(mktemp --suffix=".json"); \
+	jq 'del(${INPUT_SDS_FILES_JSON_LOCATION})' $$ext_md_json > $$ext_md_json_updated; \
 	\
 	# generate a respec JSON if not provided \
 	if [ ! -e ${RESPEC_DATA_JSON_PATH} ]; then \
@@ -473,7 +459,7 @@ generate-respec:
 	# merge the metadata and data JSON files into a single JSON file to be used \
 	# for generating the respec document \
 	merged_json=$$(mktemp --suffix=".json"); \
-	$(JQ) -s 'reduce .[] as $$item ({}; . * $$item)' ${RESPEC_DATA_JSON_PATH} $$ext_md_json > $$merged_json; \
+	$(JQ) -s 'reduce .[] as $$item ({}; . * $$item)' ${RESPEC_DATA_JSON_PATH} $$ext_md_json_updated > $$merged_json; \
 	\
 	# copy other static assets (e.g. images, examples) to the output folder \
 	cp -rf ${RESPEC_INPUT_ASSETS_DIR} ${RESPEC_OUTPUT_DIR}; \
@@ -485,7 +471,7 @@ generate-respec:
 	echo "Output respec package:"; \
 	ls -ldh ${RESPEC_OUTPUT_DIR}; \
 	command -v tree > /dev/null 2>&1 && tree "${RESPEC_OUTPUT_DIR}"; \
-	rm -f $$merged_json
+	rm -f $$merged_json $$ext_md_json $$ext_md_json_updated
 
 # A generic recipe for converting RDF data from one serialization format to 
 # another. It can also be used to regenerate a file using the same format.

--- a/test/ePO-default-config/metadata.json
+++ b/test/ePO-default-config/metadata.json
@@ -91,7 +91,33 @@
                 "title": "How to make your data FAIR",
                 "publisher": "OpenAire"
             }
-        }
+        },
+        "projectLocalResources": [
+            {
+                "name": "OWL core file",
+                "path": "/path/to/core.rdf"
+            },
+            {
+                "name": "OWL restrictions file",
+                "path": "/path/to/core_restrictions.rdf"
+            },
+            {
+                "name": "SHACL shapes file",
+                "path": "/path/to/core_shapes.ttl"
+            },
+            {
+                "name": "JSON-LD context file",
+                "path": "/path/to/core_context.jsonld"
+            },
+            {
+                "name": "UML XMI model file",
+                "path": "/path/to/core.xml"
+            },
+            {
+                "name": "UML EAP model file",
+                "path": "/path/to/CM.qea"
+            }
+        ]
     },
     "customMetadata": {
         "metadataSectionProperties": [


### PR DESCRIPTION
The package generation logic no longer assumes default values for locations of model2owl project resources (SDS) and their labels to be shown in the ReSpec HTML document. This is now expected to be controlled by the user and therefore the corresponding properties have been moved to metadata.json file.