### PR TITLE
Extend the quick reference section to include property mandatory status (TEDM2O-11)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,7 @@ MODEL_EAP_FILE_PATH?=
 # respec variables with default values
 RESPEC_JSON_INDENTATION?=2
 RESPEC_DATA_JSON_PATH?=${OUTPUT_FOLDER_PATH}/${XMI_INPUT_FILENAME_WITHOUT_EXTENSION}_respec.json
+RESPEC_CFG_JSON_PATH?=${OUTPUT_FOLDER_PATH}/${XMI_INPUT_FILENAME_WITHOUT_EXTENSION}_respec-cfg.json
 RESPEC_METADATA_JSON_PATH?=${ABSOLUTE_MODEL2OWL_FOLDER}/test/ePO-default-config/metadata.json
 RESPEC_INPUT_ASSETS_DIR=${ABSOLUTE_MODEL2OWL_FOLDER}/respec-resources/assets
 SDS_FILES_JSON_LOCATION=.assets.sdsSection
@@ -279,6 +280,21 @@ respec-json:
 	@echo Output respec json file location:
 	@ls -lh ${OUTPUT_FOLDER_PATH}/${XMI_INPUT_FILENAME_WITHOUT_EXTENSION}_respec.json
 	@rm -f ${OUTPUT_FOLDER_PATH}/${XMI_INPUT_FILENAME_WITHOUT_EXTENSION}_respec.json.tmp
+
+respec-cfg-json:
+	@java -jar ${SAXON} -s:${XMI_INPUT_FILE_PATH} -xsl:${MODEL2OWL_FOLDER}/src/rspec-cfg-json-generate.xsl \
+		-o:${OUTPUT_FOLDER_PATH}/${XMI_INPUT_FILENAME_WITHOUT_EXTENSION}_respec-cfg.json.tmp \
+		enrichedNamespacesPath="${ENRICHED_NAMESPACES_XML_PATH}" \
+		importsPath="${IMPORTS_XML_FILE_PATH}"
+	@# reformat the JSON file to be more readable
+	@cat ${OUTPUT_FOLDER_PATH}/${XMI_INPUT_FILENAME_WITHOUT_EXTENSION}_respec-cfg.json.tmp \
+		| python3 -c "import sys, json; \
+		data = json.load(sys.stdin); \
+		print(json.dumps(data, sort_keys=True, indent=int(${RESPEC_JSON_INDENTATION})))" \
+		> ${OUTPUT_FOLDER_PATH}/${XMI_INPUT_FILENAME_WITHOUT_EXTENSION}_respec-cfg.json
+	@echo Output respec json file location:
+	@ls -lh ${OUTPUT_FOLDER_PATH}/${XMI_INPUT_FILENAME_WITHOUT_EXTENSION}_respec-cfg.json
+	@rm -f ${OUTPUT_FOLDER_PATH}/${XMI_INPUT_FILENAME_WITHOUT_EXTENSION}_respec-cfg.json.tmp
 	
 # make generate-jsonld-context [XMI_INPUT_FILE_PATH=/path/to/cm.xmi] 
 #	[OUTPUT_FOLDER_PATH=/output/directory]
@@ -464,16 +480,18 @@ generate-respec:
 	handle_artefact_file $$ext_md_json "UML XMI model file" "${XMI_INPUT_FILE_PATH}" ; \
 	handle_artefact_file $$ext_md_json "UML EAP model file" "${MODEL_EAP_FILE_PATH}" ; \
 	\
-	# generate a respec JSON if not provided \
+	# generate a respec data JSON if not provided \
 	if [ ! -e ${RESPEC_DATA_JSON_PATH} ]; then \
 		echo "Generating a ReSpec JSON data file..."; \
 		$(MAKE) respec-json XMI_INPUT_FILE_PATH=${XMI_INPUT_FILE_PATH} OUTPUT_FOLDER_PATH=${OUTPUT_FOLDER_PATH} ; \
 	fi; \
 	\
+	# generate a respec config JSON file \
+	$(MAKE) respec-cfg-json XMI_INPUT_FILE_PATH=${XMI_INPUT_FILE_PATH} OUTPUT_FOLDER_PATH=${OUTPUT_FOLDER_PATH} ; \
 	# merge the metadata and data JSON files into a single JSON file to be used \
 	# for generating the respec document \
 	merged_json=$$(mktemp --suffix=".json"); \
-	$(JQ) -s 'reduce .[] as $$item ({}; . * $$item)' ${RESPEC_DATA_JSON_PATH} $$ext_md_json > $$merged_json; \
+	$(JQ) -s 'reduce .[] as $$item ({}; . * $$item)' ${RESPEC_DATA_JSON_PATH} ${RESPEC_CFG_JSON_PATH} $$ext_md_json > $$merged_json; \
 	\
 	# copy other static assets (e.g. images, examples) to the output folder \
 	cp -rf ${RESPEC_INPUT_ASSETS_DIR} ${RESPEC_OUTPUT_DIR}; \

--- a/respec-resources/templates/base.j2
+++ b/respec-resources/templates/base.j2
@@ -1,6 +1,8 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"> 
 {% set language = "en" %}
 {% set sortattr = "sort" %}
+{% set mandatoryPropLabel = "Mandatory" %}
+{% set optionalPropLabel = "Optional" %}
 {% set _docRoot = "." %}
 {% set docRoot = metadata.documentConfig.editorDocumentRoot if metadata.documentConfig.editorDocumentRoot else _docRoot %}
 
@@ -160,6 +162,21 @@
         {% endif %}
     </section>
 {% endmacro %}
+
+{% macro getMandatoryStatus(property) %}
+    {# Use the configured tag value if exists #}
+    {% if config.mandatoryStatusTagName and property.tags[config.mandatoryStatusTagName] %}
+        {{ property.tags[config.mandatoryStatusTagName] }}
+    {% else %}
+        {# Fallback to cardinality interpretation #}
+        {% if property.cardinality.startswith('0..') %}
+            {{ optionalPropLabel }}
+        {% else %}
+            {{ mandatoryPropLabel }}
+        {% endif %}
+    {% endif %}
+{% endmacro %}
+
 
 <head>	
     <meta charset="utf-8" />
@@ -570,6 +587,7 @@
                 <tr>
                     <th>Class</th>
                     <th>Class IRI</th>
+                    <th>Property type</th>
                     <th>Property</th>
                     <th>Property IRI</th>
                 </tr>
@@ -581,6 +599,7 @@
                             <tr>
                                 <td><a href="#{{ entity.label[language] | replace(' ', '') | urlencode | title }}">{{ entity.label[language] }}</a></td>
                                 <td><div class="compact-uri">{{ entity.uri }}</div></td>
+                                <td>{{ getMandatoryStatus(prop) }}</td>
                                 <td><a href="#{{ (entity.label[language] ~ '.' ~ prop.label[language]) | replace(' ', '') | urlencode | title }}">{{ prop.label[language] }} </a></td>
                                 <td><div class="compact-uri">{{ prop.uri }}</div></td>
                             </tr>

--- a/src/rspec-cfg-json-generate.xsl
+++ b/src/rspec-cfg-json-generate.xsl
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:math="http://www.w3.org/2005/xpath-functions/math"
+    xmlns:xd="http://www.oxygenxml.com/ns/doc/xsl"
+    xmlns:fn="http://www.w3.org/2005/xpath-functions"
+    xmlns:array="http://www.w3.org/2005/xpath-functions/array"
+    xmlns:uml="http://www.omg.org/spec/UML/20131001"
+    xmlns:xmi="http://www.omg.org/spec/XMI/20131001"
+    xmlns:umldi="http://www.omg.org/spec/UML/20131001/UMLDI"
+    xmlns:dc="http://www.omg.org/spec/UML/20131001/UMLDC"
+    xmlns:owl="http://www.w3.org/2002/07/owl#"
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+    xmlns:dct="http://purl.org/dc/terms/"
+    xmlns:f="http://https://github.com/costezki/model2owl#"
+    xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+    exclude-result-prefixes="xs math xd xsl uml xmi umldi dc fn array owl rdf rdfs dct f skos"
+    version="3.0">
+    
+    <xsl:output method="text" media-type="application/json" indent="no"/>
+
+    <xsl:import href="common/checkers.xsl"/>
+    <xsl:import href="common/fetchers.xsl"/>
+    
+
+    <xsl:template match="/">
+        <!-- compose root map -->
+        <xsl:variable name="rootMap" as="map(*)"
+            select="map{
+                'config': map{
+                    'mandatoryStatusTagName': string($mandatoryStatusTagName)
+                }
+            }"/>
+
+        <!-- output -->
+        <xsl:value-of
+            select="serialize($rootMap, map{'method':'json','indent':true()})"
+        />
+    </xsl:template>
+
+</xsl:stylesheet>

--- a/test/ePO-default-config/config-parameters.xsl
+++ b/test/ePO-default-config/config-parameters.xsl
@@ -99,6 +99,11 @@
      <!--    Tag names/keys that are excluded from output -->
     <xsl:variable name="excludedTagNamesList" select="($statusProperty, $cvConstraintLevelProperty)"/>
     
+    <!-- Tag name/key that is used to indicate if a property is mandatory or
+         optional. If the tag is missing then cardinality will be used to
+         determine if a property is mandatory or optional-->
+    <xsl:variable name="mandatoryStatusTagName" select="'cfg:usage'"/>
+    
     <!-- Variables for status filtering:  
      - The property used to indicate the status  
      - A list of valid statuses  


### PR DESCRIPTION
Scope of changes:

* Implemented property status generation logic in the Jinja template. The logic is based on a tag value, with fallback to property cardinality
* Implemented generation of a new JSON artefact for ReSpec configuration, required in the Jinja context (in XSLT and Make)
* Introduced a new `mandatoryStatusTagName` configuration parameter

The feature has been manualy tested.

Note: The new ReSpec configuration JSON was introduced to avoid storing configuration values in the ReSpec data JSON, as they do not belong there. Additional similar configuration parameters are planned.