### PR TITLE
Fix several minor issues in content and format of the generated ReSpec docs (TEDM2O-11)

### DIFF
--- a/respec-resources/templates/base.j2
+++ b/respec-resources/templates/base.j2
@@ -78,9 +78,13 @@
             </dt>
             {% if ((entity.properties | length) > 0 ) %}
                 <dd>
-                    For this entity the following properties are defined: {%- for prop in entity['properties'] | sort(attribute=sortattr) %} <a href="#{{ (entity.label[language] ~ '.' ~ prop.label[language]) | replace(' ','') |urlencode | title }}">{{ prop.label[language] }}</a>
-                    {% if not loop.last %},{% endif %}
-                {%- endfor %}.
+                    For this entity the following properties are defined: 
+                    {%- for prop in entity['properties'] | sort(attribute='label[language]') %}
+                        {# lower the first letter in case it's uppercase #}
+                        {% set propertyLabel = prop.label[language][:1]|lower ~ prop.label[language][1:]  %}
+                        <a href="#{{ (entity.label[language] ~ '.' ~ prop.label[language]) | replace(' ','') | urlencode | title }}">{{ propertyLabel }}</a>
+                    {%- if not loop.last %},{% endif %}
+                    {%- endfor %}.
                 </dd>
             {% else %}
                 <dd>
@@ -122,11 +126,13 @@
                                 resource="{{ prop.uri }}"
                                 class="class mandatory">
                                 <td>
+                                        {# lower the first letter in case it's uppercase #}
+                                        {% set propertyLabel = prop.label[language][:1]|lower ~ prop.label[language][1:]  %}
                                         <a href="{{ prop.uri }}"
                                         data-toggle="tooltip"
                                         data-content="{{ prop.uri }}"
                                         data-placement="right">
-                                        {{ prop.label[language] }}</a>
+                                        {{ propertyLabel }}</a>
                                 </td>
                                 <td>
                                     {% for range in prop.range %}
@@ -134,9 +140,9 @@
                                             <a href="#{{ range['range_label'][language] | replace(' ','') |urlencode | title }}"
                                             data-toggle="tooltip"
                                             data-content="{{ range['range_puri'] }}"
-                                            data-placement="right">{{ range['range_curie'] }}</a>
+                                            data-placement="right">{{ range['range_label'][language] }}</a>
                                         {% else %}
-                                            <a href="#{{ range['range_label'][language] | replace(' ','') |urlencode | title }}" data-placement="right">{{ range['range_curie'] }}</a>
+                                            <a href="#{{ range['range_label'][language] | replace(' ','') |urlencode | title }}" data-placement="right">{{ range['range_label'][language] }}</a>
                                         {% endif %}
                                     {% endfor %}
                                 </td>
@@ -578,10 +584,12 @@
                 {% for entity in classes | sort(attribute=sortattr) %}
                     {% if ((entity.properties | length) > 0 ) %}
                         {% for prop in entity['properties'] | sort(attribute=sortattr) %}
+                            {# lower the first letter in case it's uppercase #}
+                            {% set propertyLabel = prop.label[language][:1]|lower ~ prop.label[language][1:]  %}
                             <tr>
                                 <td><a href="#{{ entity.label[language] | replace(' ', '') | urlencode | title }}">{{ entity.label[language] }}</a></td>
                                 <td><div class="compact-uri">{{ entity.uri }}</div></td>
-                                <td><a href="#{{ (entity.label[language] ~ '.' ~ prop.label[language]) | replace(' ', '') | urlencode | title }}">{{ prop.label[language] }} </a></td>
+                                <td><a href="#{{ (entity.label[language] ~ '.' ~ prop.label[language]) | replace(' ', '') | urlencode | title }}">{{ propertyLabel }} </a></td>
                                 <td><div class="compact-uri">{{ prop.uri }}</div></td>
                             </tr>
                         {% endfor %}

--- a/src/rspec-json-generate.xsl
+++ b/src/rspec-json-generate.xsl
@@ -5,6 +5,7 @@
     xmlns:xd="http://www.oxygenxml.com/ns/doc/xsl"
     xmlns:fn="http://www.w3.org/2005/xpath-functions"
     xmlns:array="http://www.w3.org/2005/xpath-functions/array"
+    xmlns:map="http://www.w3.org/2005/xpath-functions/map"
     xmlns:uml="http://www.omg.org/spec/UML/20131001"
     xmlns:xmi="http://www.omg.org/spec/XMI/20131001"
     xmlns:umldi="http://www.omg.org/spec/UML/20131001/UMLDI"
@@ -15,7 +16,7 @@
     xmlns:dct="http://purl.org/dc/terms/"
     xmlns:f="http://https://github.com/costezki/model2owl#"
     xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-    exclude-result-prefixes="xs math xd xsl uml xmi umldi dc fn array owl rdf rdfs dct f skos"
+    exclude-result-prefixes="xs math xd xsl uml xmi umldi dc fn array map owl rdf rdfs dct f skos"
     version="3.0">
     
     <xsl:output method="text" media-type="application/json" indent="no"/>
@@ -35,11 +36,19 @@
         </xsl:variable>
 
         <!-- classes as array(*) via mode that returns map(*) per class -->
-        <xsl:variable name="classMaps" as="map(*)*">
+        <xsl:variable name="classMapsUnsorted" as="map(*)*">
             <xsl:apply-templates
                 select="/xmi:XMI/xmi:Extension/elements/element[@xmi:type = 'uml:Class']"
                 mode="class-json"/>
 
+        </xsl:variable>
+
+        <!-- Sort classes alphabetically by label.en -->
+        <xsl:variable name="classMaps" as="map(*)*">
+            <xsl:for-each select="$classMapsUnsorted">
+                <xsl:sort select="map:get(., 'label')?en" order="ascending"/>
+                <xsl:sequence select="."/>
+            </xsl:for-each>
         </xsl:variable>
 
         <!-- datatypes as array(*) via mode that returns map(*) per datatype -->

--- a/src/rspec/rspec-generation.xsl
+++ b/src/rspec/rspec-generation.xsl
@@ -73,8 +73,24 @@
         </xsl:variable>
 
         <!-- Merge properties arrays -->
-        <xsl:variable name="properties" as="array(*)"
+        <xsl:variable name="propertiesUnsorted" as="array(*)"
             select="array:join(($propsFromAttributes, $propsFromAssociations, $propsFromDependencies))"/>
+
+        <!-- Sort properties alphabetically by label.en -->
+        <xsl:variable name="properties" as="array(*)">
+            <xsl:variable name="propertiesSequence" as="map(*)*">
+                <xsl:for-each select="1 to array:size($propertiesUnsorted)">
+                    <xsl:sequence select="array:get($propertiesUnsorted, .)"/>
+                </xsl:for-each>
+            </xsl:variable>
+            <xsl:variable name="sortedProperties" as="map(*)*">
+                <xsl:for-each select="$propertiesSequence">
+                    <xsl:sort select="map:get(., 'label')?en" order="ascending"/>
+                    <xsl:sequence select="."/>
+                </xsl:for-each>
+            </xsl:variable>
+            <xsl:sequence select="array{$sortedProperties}"/>
+        </xsl:variable>
 
         <!-- Emit a single map(*) -->
         <xsl:sequence


### PR DESCRIPTION
Fixed issues:
* a trailing space appearing between a property label and a comma on a class properties list
* property range type now uses a human readable label instead of a compact URI
* the first letter of a property label is now lowercased
* Introduced sorting of classes in TOC and lists of properties in descriptions of classes