### PR TITLE
Support referenced terms for classes and properties in ReSpec (TEDM2O-11)

### DIFF
--- a/respec-resources/templates/base.j2
+++ b/respec-resources/templates/base.j2
@@ -73,6 +73,14 @@
                     {%- endfor %}
                 </dd>
             {% endif %}
+            {% if config.showReferencesInRespec and entity.tags[config.referenceTagName] %}
+                <dt>
+                    {{ config.classReferenceRespecLabel if config.classReferenceRespecLabel else 'References' }}
+                </dt>
+                <dd>
+                    {{ entity.tags[config.referenceTagName] | safe }}
+                </dd>
+            {% endif %}
             <dt>
                 Properties
             </dt>
@@ -108,6 +116,11 @@
                             <th class="data-table__header-title--sortable" style="width:30%">
                                 Usage
                             </th>
+                            {% if config.showReferencesInRespec %}
+                            <th class="data-table__header-title--sortable" style="width:20%">
+                                {{ config.propertyReferenceRespecLabel if config.propertyReferenceRespecLabel else 'Reuse' }}
+                            </th>
+                            {% endif %}
                             {% if metadata.openGithubIssue %}
                                 <th class="data-table__header-title--sortable data-table__header-title--sortable-active" style="width:5%">
                                     {{ metadata.openGithubIssue.columnLabel if metadata.openGithubIssue.columnLabel else 'Open an issue'}}
@@ -149,6 +162,11 @@
                                 <td property="skos:scopeNote">
                                     {{ prop.usage[language] | safe }}
                                 </td>
+                                {% if config.showReferencesInRespec %}
+                                <td>
+                                    {{ prop.tags[config.referenceTagName] | safe }}
+                                </td>
+                                {% endif %}
                                 <td>
                                     {{ renderFeedbackButton(entity, prop) }}
                                 </td>

--- a/src/rspec-cfg-json-generate.xsl
+++ b/src/rspec-cfg-json-generate.xsl
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:math="http://www.w3.org/2005/xpath-functions/math"
+    xmlns:xd="http://www.oxygenxml.com/ns/doc/xsl"
+    xmlns:fn="http://www.w3.org/2005/xpath-functions"
+    xmlns:array="http://www.w3.org/2005/xpath-functions/array"
+    xmlns:uml="http://www.omg.org/spec/UML/20131001"
+    xmlns:xmi="http://www.omg.org/spec/XMI/20131001"
+    xmlns:umldi="http://www.omg.org/spec/UML/20131001/UMLDI"
+    xmlns:dc="http://www.omg.org/spec/UML/20131001/UMLDC"
+    xmlns:owl="http://www.w3.org/2002/07/owl#"
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+    xmlns:dct="http://purl.org/dc/terms/"
+    xmlns:f="http://https://github.com/costezki/model2owl#"
+    xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+    exclude-result-prefixes="xs math xd xsl uml xmi umldi dc fn array owl rdf rdfs dct f skos"
+    version="3.0">
+    
+    <xsl:output method="text" media-type="application/json" indent="no"/>
+
+    <xsl:import href="common/checkers.xsl"/>
+    <xsl:import href="common/fetchers.xsl"/>
+    
+
+    <xsl:template match="/">
+        <!-- compose root map -->
+        <xsl:variable name="rootMap" as="map(*)"
+            select="map{
+                'config': map{
+                    'referenceTagName': string($referenceTagName),
+                    'propertyReferenceRespecLabel': string($propertyReferenceRespecLabel),
+                    'classReferenceRespecLabel': string($classReferenceRespecLabel),
+                    'showReferencesInRespec': boolean($showReferencesInRespec)
+                }
+            }"/>
+
+        <!-- output -->
+        <xsl:value-of
+            select="serialize($rootMap, map{'method':'json','indent':true()})"
+        />
+    </xsl:template>
+
+</xsl:stylesheet>

--- a/test/ePO-default-config/config-parameters.xsl
+++ b/test/ePO-default-config/config-parameters.xsl
@@ -99,6 +99,17 @@
      <!--    Tag names/keys that are excluded from output -->
     <xsl:variable name="excludedTagNamesList" select="($statusProperty, $cvConstraintLevelProperty)"/>
     
+
+    <!-- Tag name/key that is used to provide reference links/reuse information for a class or property-->
+    <xsl:variable name="referenceTagName" select="'dcterms:references'"/>
+    <!-- Label that will be used in the ReSpec docs to describe values of `referenceTagName` for properties -->
+    <xsl:variable name="propertyReferenceRespecLabel" select="'Reuse'"/>
+    <!-- Label that will be used in the ReSpec docs to describe values of `referenceTagName` for classes -->
+    <xsl:variable name="classReferenceRespecLabel" select="'Reference'"/>
+    <!-- A flag to control whether references/reuse information is shown in the ReSpec docs -->
+    <xsl:variable name="showReferencesInRespec" select="fn:true()"/>
+
+
     <!-- Variables for status filtering:  
      - The property used to indicate the status  
      - A list of valid statuses  


### PR DESCRIPTION
This change introduces the generation of the _Reuse_ table column and the _Reference_ text box for properties and classes, respectively. The feature is configurable, allowing the user to change the tag name, modify the labels of the rendered elements, or disable the feature completely.

Scope of changes:
* Updated implementation of ReSpec config JSON generation
* Added the new config properties to config file for tag, labels and enabling/disabling rendering of references
* Updated the base template to use the new properties

_Note: This feature branch uses the ReSpec config JSON file introduced in #274_