### PR TITLE
Add script testing bugfix for reused terms issue (TEDM2O-16)

### DIFF
--- a/test/reused-concepts-bugfix-testing/detect_reused_uris.py
+++ b/test/reused-concepts-bugfix-testing/detect_reused_uris.py
@@ -1,0 +1,37 @@
+"""
+Script to detect reused URIs in an RDF graph. It identifies subjects that URIs
+do not start with the specified namespace prefix.
+"""
+
+import sys
+from rdflib import Graph
+
+
+def find_reused_uris(graph):
+    query = """
+        PREFIX a4g: <http://data.europa.eu/a4g/ontology#>
+
+        SELECT ?s ?p ?o
+        WHERE {
+            ?s ?p ?o
+            FILTER (isURI(?s) && (!STRSTARTS(str(?s), str(a4g:))))
+        }
+    """
+    return [row for row in graph.query(query)]
+    
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("Usage: python detect_reused_uris.py <input_file>")
+        sys.exit(1)
+
+    input_file = sys.argv[1]
+    g = Graph()
+    g.parse(input_file, format="turtle")
+
+    found_triples = find_reused_uris(g)
+    assert not found_triples, (
+        f"Reused URIs found in triples for file {input_file}.\n"
+        f"Found triples:\n{found_triples}"
+    )
+    print(f"No reused URIs found in file {input_file}.")


### PR DESCRIPTION
The change adds a script for detecting any terms that are redefined in a given RDF ontology file. A term is considered redefined when a triple with its URI in the subject position is present.
The script aims to reproduce the bug reported in the TEDM2O-16 ticket. It is used on a [dedicated branch in the ePO repository](https://github.com/OP-TED/ePO/tree/test-reused-terms-bugfix), created for reproducing the bug and demonstrating the fix.