### PR TITLE
Updated implementation of JSON-LD context file generation (TEDM2O-7)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -295,6 +295,7 @@ respec-cfg-json:
 # where:
 #   JSONLD_CONTEXT_INDENTATION: Indentation for the generated file (defaults to 2 spaces)
 generate-jsonld-context:
+	@make gen-enriched-ns-file
 	@java -jar ${SAXON} -s:${XMI_INPUT_FILE_PATH} -xsl:${MODEL2OWL_FOLDER}/src/jsonld-context.xsl \
 		-o:${OUTPUT_FOLDER_PATH}/${XMI_INPUT_FILENAME_WITHOUT_EXTENSION}_context.jsonld.tmp \
 		enrichedNamespacesPath="${ENRICHED_NAMESPACES_XML_PATH}"

--- a/src/common/fetchers.xsl
+++ b/src/common/fetchers.xsl
@@ -72,6 +72,16 @@
         <xsl:sequence select="root($element)//connector[source/@xmi:idref = $element/@xmi:idref]"/>
     </xsl:function>
     
+    <xd:doc>
+        <xd:desc>Get the connectors outgoing from the element by type</xd:desc>
+        <xd:param name="element"/>
+    </xd:doc>
+    <xsl:function name="f:getOutgoingConnectorsByType" as="node()*">
+        <xsl:param name="element" as="node()"/>
+        <xsl:param name="connectorTypes" as="xs:string*"/>
+        <xsl:variable name="connectors" select="f:getOutgoingConnectors($element)"/>
+        <xsl:sequence select="$connectors[properties/@ea_type = $connectorTypes]"/>
+    </xsl:function>
 
     <xd:doc>
         <xd:desc>Get the connectors incomming to the element</xd:desc>
@@ -416,6 +426,31 @@
         <relations>
             <xsl:for-each select="$root//connector[properties/@ea_type = $connectorTypes]">
                 <xsl:sequence select="f:getRelationsFromConnector(.)"/>
+            </xsl:for-each>
+        </relations>
+    </xsl:function>
+
+    <xd:doc>
+        <xd:desc>
+            Get all relations of the given types outgoing from the specified
+            class that are encoded in the connectors. The function accepts a
+            sequence of connector types (e.g., 'Association',
+            'Generalization') and returns a sequence of internal relation
+            elements (see `f:createRelation` function).
+            See `f:getRelationsFromConnector` for the definition of the relation
+            concept.
+        </xd:desc>
+        <xd:param name="class"/>
+        <xd:param name="connectorTypes"/>
+    </xd:doc>
+    <xsl:function name="f:getOutgoingRelationsByType">
+        <xsl:param name="class" as="node()"/>
+        <xsl:param name="connectorTypes" as="xs:string*"/>
+        <xsl:variable name="className" select="$class/@name"/>
+        <relations>
+            <xsl:for-each select="f:getOutgoingConnectorsByType($class, $connectorTypes)">
+                <xsl:variable name="relations" select="f:getRelationsFromConnector(.)"/>
+                <xsl:sequence select="$relations[source/@name = $className]"/>
             </xsl:for-each>
         </relations>
     </xsl:function>

--- a/src/common/utils.xsl
+++ b/src/common/utils.xsl
@@ -127,6 +127,27 @@
     </xsl:function>
 
     <xd:doc>
+        <xd:desc>
+            Function to get the local segment from a term Qname / compact URI
+            (prefix:LocalSegment), excluding the namespace prefix if it matches
+            the processed ontology prefix.
+        </xd:desc>
+    </xd:doc>
+    <xsl:function name="f:getLocalSegmentForInternalTerm">
+        <xsl:param name="termCurie"/>
+        <xsl:value-of>
+            <xsl:choose>
+                <xsl:when test="f:getPrefix($termCurie) = f:getMetadataValue('preferredNamespacePrefix')">
+                    <xsl:value-of select="f:getLocalSegment($termCurie)"/>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:value-of select="$termCurie"/>
+                </xsl:otherwise>
+            </xsl:choose>
+        </xsl:value-of>
+    </xsl:function>
+
+    <xd:doc>
         <xd:desc>Get the prefix from a Qname (prefix:LocalSegment).</xd:desc>
         <xd:param name="name"/>
     </xd:doc>

--- a/src/common/utils.xsl
+++ b/src/common/utils.xsl
@@ -135,16 +135,14 @@
     </xd:doc>
     <xsl:function name="f:getLocalSegmentForInternalTerm">
         <xsl:param name="termCurie"/>
-        <xsl:value-of>
-            <xsl:choose>
-                <xsl:when test="f:getPrefix($termCurie) = f:getMetadataValue('preferredNamespacePrefix')">
-                    <xsl:value-of select="f:getLocalSegment($termCurie)"/>
-                </xsl:when>
-                <xsl:otherwise>
-                    <xsl:value-of select="$termCurie"/>
-                </xsl:otherwise>
-            </xsl:choose>
-        </xsl:value-of>
+        <xsl:choose>
+            <xsl:when test="f:getPrefix($termCurie) = f:getMetadataValue('preferredNamespacePrefix')">
+                <xsl:sequence select="f:getLocalSegment($termCurie)"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:sequence select="$termCurie"/>
+            </xsl:otherwise>
+        </xsl:choose>
     </xsl:function>
 
     <xd:doc>

--- a/src/jsonld-context-lib/common-jsonld-context.xsl
+++ b/src/jsonld-context-lib/common-jsonld-context.xsl
@@ -30,19 +30,27 @@
             Output should be used in conjunction with the `fn:map` node.
         </xd:desc>
     </xd:doc>
-    <xsl:template name="elementDeclaration">
+    <xsl:template name="simpleElementDeclaration">
         <xsl:variable name="elementCurie" select="./@name"/>
-        <xsl:variable name="elementName">
-            <xsl:choose>
-                <xsl:when test="f:getPrefix($elementCurie) = f:getMetadataValue('preferredNamespacePrefix')">
-                    <xsl:value-of select="f:getLocalSegment($elementCurie)"/>
-                </xsl:when>
-                <xsl:otherwise>
-                    <xsl:value-of select="$elementCurie"/>
-                </xsl:otherwise>
-            </xsl:choose>
-        </xsl:variable>
+        <xsl:variable name="elementName" select="f:getLocalSegmentForInternalTerm($elementCurie)"/>
         <xsl:variable name="elementUri" select="f:buildURIfromLexicalQName($elementCurie)"/>
         <fn:string key="{$elementName}"><xsl:value-of select="$elementUri"/></fn:string>        
+    </xsl:template>
+
+    <xd:doc>
+        <xd:desc>
+            A generic template for declaring term ID mapping in the JSON-LD
+            context. It generates a mapping from the term name to its URI.
+            Suitable for such UML elements as Class, Property and Association.
+            The function skips the namespace prefix if it matches the
+            preferred namespace prefix.
+            Output should be used in conjunction with the `fn:map` node.    
+        </xd:desc>
+        <xd:param name="termCurie"/>
+    </xd:doc>
+    <xsl:template name="termIdMapping">
+        <xsl:param name="termCurie"/>
+        <xsl:variable name="termUri" select="f:buildURIfromLexicalQName($termCurie)"/>
+        <fn:string key="@id"><xsl:value-of select="$termUri"/></fn:string>   
     </xsl:template>
 </xsl:stylesheet>

--- a/src/jsonld-context-lib/connectors-jsonld-context.xsl
+++ b/src/jsonld-context-lib/connectors-jsonld-context.xsl
@@ -22,24 +22,18 @@
 
     <xd:doc>
         <xd:desc>
-            Generates node objects for associations and dependencies that are not
-            excluded based on their status or origin.
-            The function correclty handles the case when a class has more than
-            one connector with the same name (target role name). The described
-            edge case is allowed in the UML standard, but it cannot be processed
-            as-is because it would lead to duplicate keys in the JSON-LD
-            context. In case of such a situation, the function uses the first
-            found connector with the given name.
+            Generates node objects for associations and dependencies of the
+            given class that are not excluded based on their status or origin.
         </xd:desc>
     </xd:doc>
-    <xsl:template name="connectorsDeclaration">
-        <xsl:variable name="supportedConnTypes" select="('Association', 'Dependency')"/>
-        <xsl:variable name="relations" select="f:getAllRelations($supportedConnTypes, root())"/>
-
-        <xsl:for-each-group select="$relations//relation" group-by="@name">
-            <xsl:for-each-group select="." group-by="source/@name">
-                <!-- Use the first connector (relation) with the certain name -->
-                <xsl:variable name="relation" select="current-group()[1]"/>
+    <xsl:template name="classConnectorsDeclaration">
+        <xsl:variable name="class" select="."/>
+        <xsl:variable name="supportedConnTypes"
+            select="('Association', 'Dependency')"/>
+        <xsl:variable name="relations"
+            select="f:getOutgoingRelationsByType($class, $supportedConnTypes)"/>
+        <xsl:for-each select="$relations//relation">
+                <xsl:variable name="relation" select="."/>
                 <xsl:variable name="connector"
                     select="f:getConnectorByIdRef($relation/@connectorIdRef, root())"/>
                 <xsl:if test="not(f:isExcludedByStatus($connector))">
@@ -55,8 +49,7 @@
                         </xsl:if>
                     </xsl:if>
                 </xsl:if>
-            </xsl:for-each-group>
-        </xsl:for-each-group>
+        </xsl:for-each>
     </xsl:template>
 
     <xd:doc>
@@ -69,10 +62,8 @@
     <xsl:template name="relationGeneration">
         <xsl:param name="relation"/>
         <xsl:variable name="relCurie" select="$relation/@name"/>
-        <xsl:variable name="sourceClassCurie" select="$relation/source/@name"/>
         <xsl:variable name="relName" select="f:getLocalSegment($relCurie)"/>
-        <xsl:variable name="sourceClassName" select="f:getLocalSegment($sourceClassCurie)"/>
-        <fn:map key="{$sourceClassName}.{$relName}">
+        <fn:map key="{$relName}">
             <xsl:call-template name="relationDeclaration">
                 <xsl:with-param name="relCurie" select="$relCurie"/>
             </xsl:call-template>
@@ -88,9 +79,10 @@
             R.03. Association and dependency — in JSON-LD context layer.
             For each UML association/dependency, specify an object property by
             creating a property URI mapping with an absolute URI of a target end
-            in a node object. Set the term definition as a top-level entry of
-            the context object. For bidirectional connectors, additionally
-            specify an extended term definition for the source end.
+            in a node object. Set the term definition as a top-level entry
+            inside the class’s inner context object. For bidirectional
+            connectors, additionally specify an extended term definition for the
+            source end.
         </xd:desc>
         <xd:param name="relCurie"/>
     </xd:doc>
@@ -107,8 +99,9 @@
             range by creating a type coercion entry in a node object. Set the
             fixed @id keyword as a value to indicate that that the value of the
             term should be interpreted as an URI. Set the term definition as a
-            top-level entry of the context object. For bidirectional connectors,
-            additionally specify the object property range for the source end.
+            top-level entry inside the class’s inner context object. For
+            bidirectional connectors, additionally specify the object property
+            range for the source end.
         </xd:desc>
     </xd:doc>
     <xsl:template name="relationTypeDeclaration">

--- a/src/jsonld-context-lib/datatypes-jsonld-context.xsl
+++ b/src/jsonld-context-lib/datatypes-jsonld-context.xsl
@@ -40,7 +40,7 @@
             <xsl:variable name="elemPrefix" select="f:getPrefix(./@name)"/>
             <!-- Check if the UML element should be processed -->
             <xsl:if test="$generateReusedConceptsJSONLDcontext or $elemPrefix = $includedPrefixesList">
-                <xsl:call-template name="elementDeclaration"/>
+                <xsl:call-template name="simpleElementDeclaration"/>
             </xsl:if>
         </xsl:if>
     </xsl:template>

--- a/src/jsonld-context-lib/elements-jsonld-context.xsl
+++ b/src/jsonld-context-lib/elements-jsonld-context.xsl
@@ -108,9 +108,7 @@
                 <!-- Check if the attribute should be processed -->
                 <xsl:if
                     test="$generateReusedConceptsJSONLDcontext or $attributePrefix = $includedPrefixesList">
-                    <xsl:call-template name="attributeGeneration">
-                        <xsl:with-param name="class" select="$class"/>
-                    </xsl:call-template>
+                    <xsl:call-template name="attributeGeneration"/>
                 </xsl:if>
             </xsl:if>
         </xsl:for-each>
@@ -121,10 +119,8 @@
             Generates a node object for the class attribute. Includes the
             attribute URI mapping, type, and container information.
         </xd:desc>
-        <xd:param name="class"/>
     </xd:doc>
     <xsl:template name="attributeGeneration">
-        <xsl:param name="class"/>
         <xsl:variable name="attribute" select="."/>
         <xsl:variable name="attrCurie" select="$attribute/@name"/>
         <xsl:variable name="attrName" select="f:getLocalSegment($attrCurie)"/>

--- a/src/jsonld-context-lib/elements-jsonld-context.xsl
+++ b/src/jsonld-context-lib/elements-jsonld-context.xsl
@@ -18,14 +18,16 @@
 
 
     <xsl:import href="../common/checkers.xsl"/>
+    <xsl:import href="connectors-jsonld-context.xsl"/>
     <xsl:import href="common-jsonld-context.xsl"/>
     
     <xsl:output method="xml" encoding="UTF-8"/>
 
     <xd:doc>
         <xd:desc>
-            Selector to run JSON-LD context transformation rules for classes and
-            attributes.
+            Selector to run JSON-LD context transformation rules for classes.
+            The transformation includes class properties, namely attributes and
+            relationships.
         </xd:desc>
     </xd:doc>
     <xsl:template match="element[@xmi:type = 'uml:Class']">
@@ -34,7 +36,6 @@
             <!-- Check if the class should be processed -->
             <xsl:if test="$generateReusedConceptsJSONLDcontext or $classPrefix = $includedPrefixesList">
                 <xsl:call-template name="classDeclaration"/>
-                <xsl:call-template name="generatePropertiesFromClassAttributes"/>
             </xsl:if>
         </xsl:if>
     </xsl:template>
@@ -43,12 +44,50 @@
         <xd:desc>
             Rule C.03. Class — in JSON-LD context layer.
             Specify a term for each UML class by assigning an absolute URI of
-            the class to the class name. Create the term mapping as a top-level
-            entry of the context object.
+            the class to the class name. Define a simple term definition or, an
+            expanded term definition if the class includes properties. Create
+            the term mapping as a top-level entry of the context object.
         </xd:desc>
     </xd:doc>
     <xsl:template name="classDeclaration">
-        <xsl:call-template name="elementDeclaration"/>
+        <xsl:variable name="class" select="."/>
+        <xsl:variable name="supportedConnTypes"
+            select="('Association', 'Dependency')"/>
+        <xsl:variable name="hasObjectProperties"
+            select="exists(f:getOutgoingConnectorsByType($class, $supportedConnTypes))"/>
+        <xsl:variable name="hasDatatypeProperties" select="count($class/attributes) > 0"/>
+        <xsl:choose>
+            <xsl:when test="$hasObjectProperties or $hasDatatypeProperties">
+                <xsl:call-template name="expandedClassDeclaration"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:call-template name="simpleElementDeclaration"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+
+    <xd:doc>
+        <xd:desc>
+            Generates an expanded term definition for a class that contains
+            either attributes or has associated relationships. The expanded
+            definition includes the class URI mapping and a nested context with
+            property definitions.
+        </xd:desc>
+    </xd:doc>
+    <xsl:template name="expandedClassDeclaration" as="element(fn:map)">
+        <xsl:variable name="class" select="."/>
+        <xsl:variable name="classCurie" select="./@name"/>
+        <xsl:variable name="className" select="f:getLocalSegmentForInternalTerm($classCurie)"/>
+        <fn:map key="{$className}">
+            <xsl:call-template name="termIdMapping">
+                <xsl:with-param name="termCurie" select="$classCurie"/>
+            </xsl:call-template>
+            <fn:map key="@context">
+                <xsl:call-template name="classAttributesDeclaration"/>
+                <xsl:call-template name="classConnectorsDeclaration"/>
+            </fn:map>
+        </fn:map>
     </xsl:template>
 
 
@@ -58,10 +97,9 @@
             excluded based on their status or origin.
         </xd:desc>
     </xd:doc>
-    <xsl:template name="generatePropertiesFromClassAttributes">
+    <xsl:template name="classAttributesDeclaration">
         <xsl:variable name="class" select="."/>
         <xsl:for-each select="$class/attributes/attribute">
-            <!-- Use the first found attribute -->
             <xsl:variable name="attribute" select="."/>
             <xsl:variable name="attributeName" select="$attribute/@name"/>
             <xsl:if test="not(f:isExcludedByStatus($attribute))">
@@ -89,10 +127,8 @@
         <xsl:param name="class"/>
         <xsl:variable name="attribute" select="."/>
         <xsl:variable name="attrCurie" select="$attribute/@name"/>
-        <xsl:variable name="classCurie" select="$class/@name"/>
         <xsl:variable name="attrName" select="f:getLocalSegment($attrCurie)"/>
-        <xsl:variable name="className" select="f:getLocalSegment($classCurie)"/>
-        <fn:map key="{$className}.{$attrName}">
+        <fn:map key="{$attrName}">
             <xsl:call-template name="attributeDeclaration">
                 <xsl:with-param name="attrCurie" select="$attrCurie"/>
             </xsl:call-template>
@@ -110,15 +146,16 @@
             C.08. Attribute — in JSON-LD context layer.
             For each UML class attribute, specify a datatype property by
             creating a property URI mapping with an absolute attribute URI in a
-            node object. Set the term definition as a top-level entry of the
-            context object.
+            node object. Set the term definition as a top-level entry inside the
+            class’s inner context object.
             </xd:desc>
         <xd:param name="attrCurie"/>
     </xd:doc>
     <xsl:template name="attributeDeclaration">
         <xsl:param name="attrCurie"/>
-        <xsl:variable name="attrUri" select="f:buildURIfromLexicalQName($attrCurie)"/>
-        <fn:string key="@id"><xsl:value-of select="$attrUri"/></fn:string>   
+        <xsl:call-template name="termIdMapping">
+            <xsl:with-param name="termCurie" select="$attrCurie"/>
+        </xsl:call-template>
     </xsl:template>
 
     <xd:doc>
@@ -126,8 +163,8 @@
             C.11. Class attribute type — in JSON-LD context layer
             For each UML class attribute, specify its range by creating a type
             coercion entry with an absolute URI of the attribute datatype in a
-            node object. Set the term definition as a top-level entry of the
-            context object.
+            node object. Set the term definition as a top-level entry inside the
+            class’s inner context object.
         </xd:desc>
         <xd:param name="attribute"/>
     </xd:doc>

--- a/src/jsonld-context.xsl
+++ b/src/jsonld-context.xsl
@@ -20,20 +20,20 @@
 
 
     <xsl:import href="jsonld-context-lib/elements-jsonld-context.xsl"/>
-    <xsl:import href="jsonld-context-lib/connectors-jsonld-context.xsl"/>
     <xsl:import href="jsonld-context-lib/datatypes-jsonld-context.xsl"/>
     
     <xsl:output method="text" encoding="UTF-8"/>
     
     <xd:doc>
-        <xd:desc>The main template for JSON-LD context file</xd:desc>
+        <xd:desc>
+            The main template for JSON-LD context file
+        </xd:desc>
     </xd:doc>
     <xsl:template match="/" >
         <xsl:variable name="json-xml" as="element(fn:map)">
             <fn:map>
                 <fn:map key="@context">
                     <xsl:apply-templates select="xmi:XMI/xmi:Extension/elements/element"/>
-                    <xsl:call-template name="connectorsDeclaration"/>
                     <xsl:call-template name="namespacesDeclaration"/>
                 </fn:map>
             </fn:map>

--- a/test/functionalTests/__init__.py
+++ b/test/functionalTests/__init__.py
@@ -2,4 +2,5 @@ import pathlib
 
 PROJECT_DIR_PATH = pathlib.Path(__file__).parent.parent.parent
 ROOT_TEST_DATA_PATH = (PROJECT_DIR_PATH / "test" / "testData")
-NAMESPACES_FILE = PROJECT_DIR_PATH / "model2owl-config" / "namespaces.xml"
+ROOT_DEAFULT_CFG_PATH = (PROJECT_DIR_PATH / "test" / "ePO-default-config")
+NAMESPACES_FILE = ROOT_DEAFULT_CFG_PATH / "namespaces.xml"

--- a/test/testData/ePO-core-4.2.0.xml
+++ b/test/testData/ePO-core-4.2.0.xml
@@ -39824,7 +39824,7 @@
 				</source>
 				<target xmi:idref="EAID_BF1B4E2A_7D4A_4247_8B45_5AD2427938E3">
 					<model ea_localid="230" type="Enumeration" name="at-voc:environmental-impact"/>
-					<role name="epo:fulfillsRequirement" visibility="Public" targetScope="instance"/>
+					<role name="epo:fulfillsEnvironmentalRequirement" visibility="Public" targetScope="instance"/>
 					<type multiplicity="0..*" aggregation="none" containment="Unspecified"/>
 					<constraints/>
 					<modifiers isOrdered="false" changeable="none" isNavigable="true"/>
@@ -39837,7 +39837,7 @@
 				<properties ea_type="Dependency" direction="Source -&gt; Destination"/>
 				<documentation value="The requirement to which the concept meets.&#xA;&#xA;"/>
 				<appearance linemode="3" linecolor="-1" linewidth="0" seqno="0" headStyle="0" lineStyle="0"/>
-				<labels rb="0..*" rt="+epo:fulfillsRequirement"/>
+				<labels rb="0..*" rt="+epo:fulfillsEnvironmentalRequirement"/>
 				<extendedProperties virtualInheritance="0"/>
 				<style/>
 				<xrefs/>

--- a/test/testData/jsonld-context/ePO_data-compacted.jsonld
+++ b/test/testData/jsonld-context/ePO_data-compacted.jsonld
@@ -3,22 +3,21 @@
     {
       "@id": "http://data.europa.eu/a4g/resource/buyer_001",
       "@type": "Buyer",
-      "Buyer.hasBuyerProfile": "https://example.com",
-      "Buyer.isContractingEntity": true,
-      "AgentInRole.playedBy": "http://data.europa.eu/a4g/resource/organization_001"
+      "hasBuyerProfile": "https://example.com",
+      "isContractingEntity": true
     },
     {
       "@id": "http://data.europa.eu/a4g/resource/organization_001",
       "@type": "org:Organization",
-      "Organization.hasBuyerLegalType": "at-voc:buyer-legal-type/pub-undert",
-      "Organization.hasLegalIdentifier": [
+      "hasBuyerLegalType": "at-voc:buyer-legal-type/pub-undert",
+      "hasLegalIdentifier": [
         "http://data.europa.eu/a4g/resource/identifier_001"
       ],
-      "Organization.hasLegalName": [
+      "hasLegalName": [
         "Fancy Organization"
       ],
-      "Organization.hasMainActivity": "at-voc:main-activity/rail",
-      "Person.registeredAddress": "http://data.europa.eu/a4g/resource/address_001"
+      "hasMainActivity": "at-voc:main-activity/rail",
+      "registeredAddress": "http://data.europa.eu/a4g/resource/address_001"
     },
     {
       "@id": "http://data.europa.eu/a4g/resource/identifier_001",
@@ -27,8 +26,8 @@
     {
       "@id": "http://data.europa.eu/a4g/resource/address_001",
       "@type": "locn:Address",
-      "Location.hasCountryCode": "at-voc:country/USA",
-      "Location.hasNutsCode": "http://data.europa.eu/nuts/code/EL303",
+      "hasCountryCode": "at-voc:country/USA",
+      "hasNutsCode": "http://data.europa.eu/nuts/code/EL303",
       "locn:fullAddress": "1248 Maplewood Drive, Springfield, IL 62704, USA",
       "locn:postCode": "62704",
       "locn:postName": "Springfield"

--- a/test/testData/jsonld-context/expected_test_data.jsonld
+++ b/test/testData/jsonld-context/expected_test_data.jsonld
@@ -15,11 +15,6 @@
         "@type": "http://www.w3.org/2001/XMLSchema#boolean",
         "@value": true
       }
-    ],
-    "http://data.europa.eu/a4g/ontology#playedBy": [
-      {
-        "@id": "http://data.europa.eu/a4g/resource/organization_001"
-      }
     ]
   },
   {

--- a/test/unitTests/test-common/test-fetchers.xspec
+++ b/test/unitTests/test-common/test-fetchers.xspec
@@ -337,6 +337,39 @@
             </x:expect>
         </x:scenario>
     </x:scenario>
+    
+    <x:scenario label="Get outgoing class relations by type">
+        <x:call function="f:getOutgoingRelationsByType">
+            <x:param name="class" href="../../testData/ePO-core-4.2.0.xml"
+                select="/xmi:XMI/xmi:Extension[1]/elements[1]/element[@name='epo:Technique']"/>
+            <x:param name="connectorTypes"
+                select="('Association', 'Dependency')"/>
+        </x:call>
+        <x:expect>
+            <relations xmlns:dct="http://purl.org/dc/terms/"
+                xmlns:f="http://https://github.com/costezki/model2owl#"
+                xmlns:fn="http://www.w3.org/2005/xpath-functions"
+                xmlns:owl="http://www.w3.org/2002/07/owl#"
+                xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+                xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+                xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+                xmlns:uml="http://www.omg.org/spec/UML/20131001"
+                xmlns:xmi="http://www.omg.org/spec/XMI/20131001">
+                <relation name="epo:hasValidityPeriod"
+                    multiplicity="0..1"
+                    connectorIdRef="EAID_DE5098A6_B134_4261_8994_841365A27FAB">
+                    <source name="epo:Technique" type="Class"/>
+                    <target name="epo:Period" type="Class"/>
+                </relation>
+                <relation name="epo:hasUsage"
+                    multiplicity="0..1"
+                    connectorIdRef="EAID_8FF77444_1F49_4895_AA8E_5C76444F3AE1">
+                    <source name="epo:Technique" type="Class"/>
+                    <target name="at-voc:usage" type="Enumeration"/>
+                </relation>
+            </relations>
+        </x:expect>
+    </x:scenario>
 
     <x:scenario label="Get definition from a connector">
         <x:call function="f:getDocumentationForConnector">

--- a/test/unitTests/test-common/test-utils.xspec
+++ b/test/unitTests/test-common/test-utils.xspec
@@ -110,6 +110,21 @@
         </x:call>
         <x:expect label="correct local segment" select="'Site'"/>
     </x:scenario>
+
+    <x:scenario label="Scenario getting the local segment for internal term">
+        <x:scenario label="Scenario getting the local segment for internal term - internal term">
+            <x:call function="f:getLocalSegmentForInternalTerm">
+                <x:param name="termCurie" select="'epo:Business'"/>
+            </x:call>
+            <x:expect label="correct local segment" select="string('Business')"/>
+        </x:scenario>
+        <x:scenario label="Scenario getting the local segment for internal term - external term">
+            <x:call function="f:getLocalSegmentForInternalTerm">
+                <x:param name="termCurie" select="'adms:Identifier'"/>
+            </x:call>
+            <x:expect label="correct local segment" select="string('adms:Identifier')"/>
+        </x:scenario>
+    </x:scenario>
     
     <x:scenario label="Scenario xsd:integer for testing function buildQNameFromLexicalQName">
         <x:call function="f:buildQNameFromLexicalQName">

--- a/test/unitTests/test-jsonld-context-lib/test-common-jsonld-context.xspec
+++ b/test/unitTests/test-jsonld-context-lib/test-common-jsonld-context.xspec
@@ -6,12 +6,12 @@
     xmlns:fn="http://www.w3.org/2005/xpath-functions"
     stylesheet="../../../src/jsonld-context-lib/common-jsonld-context.xsl">
 
-    <x:scenario label="Scenario for UML element name to URI mapping - elementDeclaration">
+    <x:scenario label="Scenario for UML element name to URI mapping - simpleElementDeclaration">
         <x:scenario label="Scenario for an internal class">
             <x:context
                 href="../../testData/ePO-core-4.2.0.xml"
                 select="/xmi:XMI/xmi:Extension[1]/elements[1]/element[108]"/>
-            <x:call template="elementDeclaration"/>
+            <x:call template="simpleElementDeclaration"/>
             <x:expect label="there is an object entry" test="boolean(/fn:string)"/>
             <x:expect label="the object entry has correct key" test="/fn:string/@key = 'AwardCriterion'"/>
             <x:expect label="the object entry has correct value"
@@ -21,7 +21,7 @@
             <x:context
                 href="../../testData/ePO-core-4.2.0.xml"
                 select="/xmi:XMI/xmi:Extension[1]/elements[1]/element[308]"/>
-            <x:call template="elementDeclaration"/>
+            <x:call template="simpleElementDeclaration"/>
             <x:expect label="there is an object entry" test="boolean(/fn:string)"/>
             <x:expect label="the object entry has correct key" test="/fn:string/@key = 'time:TemporalUnit'"/>
             <x:expect label="the object entry has correct value"
@@ -31,7 +31,7 @@
             <x:context
                 href="../../testData/ePO-core-4.2.0.xml"
                 select="/xmi:XMI/xmi:Extension[1]/elements[1]/element[313]"/>
-            <x:call template="elementDeclaration"/>
+            <x:call template="simpleElementDeclaration"/>
             <x:expect label="there is an object entry" test="boolean(/fn:string)"/>
             <x:expect label="the object entry has correct key" test="/fn:string/@key = 'xsd:boolean'"/>
             <x:expect label="the object entry has correct value"
@@ -41,7 +41,7 @@
             <x:context
                 href="../../testData/ePO-core-4.2.0.xml"
                 select="/xmi:XMI/xmi:Extension[1]/elements[1]/element[90]"/>
-            <x:call template="elementDeclaration"/>
+            <x:call template="simpleElementDeclaration"/>
             <x:expect label="there is an object entry" test="boolean(/fn:string)"/>
             <x:expect label="the object entry has correct key" test="/fn:string/@key = 'adms:Identifier'"/>
             <x:expect label="the object entry has correct value" test="/fn:string/text() = 'http://www.w3.org/ns/adms#Identifier'"/>

--- a/test/unitTests/test-jsonld-context-lib/test-connectors-jsonld-context.xspec
+++ b/test/unitTests/test-jsonld-context-lib/test-connectors-jsonld-context.xspec
@@ -7,25 +7,23 @@
     xmlns:f="http://https://github.com/costezki/model2owl#" 
     stylesheet="../../../src/jsonld-context-lib/connectors-jsonld-context.xsl">
 
-    <x:scenario label="Scenario for generation of context for all connectors - connectorsDeclaration">
-        <x:context
-            href="../../testData/ePO-core-4.2.0.xml" select="/"/>
-        <x:call template="connectorsDeclaration"/>
-        <x:expect label="there is an object entry" test="boolean(/fn:map)"/>
-        <x:expect label="there is object for internal association"
-            test="boolean(/fn:map[@key='ReviewDecision.resolvesReviewRequest'])"/>
-        <x:expect label="there is object for external association"
-            test="boolean(/fn:map[@key='Person.registeredAddress'])"/>
-        <x:expect label="there are objects for bidirectional association"
-        test="boolean(/fn:map[@key='System.isOwnedByAgent']) and boolean(/fn:map[@key='Agent.ownsSystem'])"/>
-        <x:expect label="there is object for internal dependency"
-            test="boolean(/fn:map[@key='AwardCriterion.hasAwardCriterionType'])"/>
-        <x:expect label="there is object for external dependency"
-            test="boolean(/fn:map[@key='Constraint.hasThresholdType'])"/>
-            <x:expect label="there are objects for the same relation associated with two different connectors"
-            test="boolean(/fn:map[@key='ResultNotice.refersToRole']) and boolean(/fn:map[@key='CompletionNotice.refersToRole'])"/>
-        <x:expect label="there is no object for excluded association (epo:status == 'proposed')"
-            test="not(boolean(/fn:map[@key='ProcurementElement.hasEstimatedValue']))"/>
+    <x:scenario label="Scenario for generation of context for class connectors - classConnectorsDeclaration">
+        <x:scenario label="Scenario for generation of context for class connectors">
+            <x:context
+                href="../../testData/ePO-core-4.2.0.xml"
+                select="/xmi:XMI/xmi:Extension[1]/elements[1]/element[@name='epo:AwardDecision']"/>
+            <x:call template="classConnectorsDeclaration"/>
+            <x:expect label="there is an object entry" test="boolean(/fn:map)"/>
+            <x:expect label="there is an object for the right association"
+                test="boolean(fn:map['comprisesAwardOutcome'])"/>
+        </x:scenario>
+        <x:scenario label="Scenario for a class without connectors">
+            <x:context
+                href="../../testData/ePO-core-4.2.0.xml"
+                select="/xmi:XMI/xmi:Extension[1]/elements[1]/element[@name='epo:AwardingCentralPurchasingBody']"/>
+            <x:call template="classConnectorsDeclaration"/>
+            <x:expect label="nothing is generated" select="()"/>
+        </x:scenario>
     </x:scenario>
 
     <x:scenario label="Scenario for relation entry generation - relationGeneration">
@@ -35,7 +33,7 @@
                     href="../../testData/ePO-core-4.2.0.xml"
                     select="f:getRelationsFromConnector(/xmi:XMI/xmi:Extension[1]/connectors[1]/connector[604])[1]"/>
             </x:call>
-            <x:expect label="the object has correct key" test="/fn:map/@key = 'SubmissionTerm.definesTenderProcessor'"/>
+            <x:expect label="the object has correct key" test="/fn:map/@key = 'definesTenderProcessor'"/>
             <x:expect label="there is an object entry with @id key" test="fn:map/fn:string/@key = '@id'"/>
             <x:expect label="there is an object entry with @type key" test="fn:map/fn:string/@key = '@type'"/>
             <x:expect label="there is no object entry with @container key" test="not(fn:map/fn:string[@key = '@container'])"/>
@@ -47,7 +45,7 @@
                     select="f:getRelationsFromConnector(/xmi:XMI/xmi:Extension[1]/connectors[1]/connector[595])[1]"/>
             </x:call>
             <x:expect label="there is an object" test="boolean(/fn:map)"/>
-            <x:expect label="the object has correct key" test="/fn:map/@key = 'Tender.specifiesSubcontractors'"/>
+            <x:expect label="the object has correct key" test="/fn:map/@key = 'specifiesSubcontractors'"/>
             <x:expect label="there is an object entry with @id key" test="fn:map/fn:string/@key = '@id'"/>
             <x:expect label="there is an object entry with @type key" test="fn:map/fn:string/@key = '@type'"/>
             <x:expect label="there is an object entry with @container key" test="fn:map/fn:string/@key = '@container'"/>

--- a/test/unitTests/test-jsonld-context-lib/test-elements-jsonld-context.xspec
+++ b/test/unitTests/test-jsonld-context-lib/test-elements-jsonld-context.xspec
@@ -6,67 +6,122 @@
     xmlns:fn="http://www.w3.org/2005/xpath-functions"
     stylesheet="../../../src/jsonld-context-lib/elements-jsonld-context.xsl">
 
-    <x:scenario label="Scenario for class declaration - testing template with match 'element[@xmi:type = 'uml:Class']">
+    <x:scenario label="Scenario for conditional generation of a class declaration - testing template with match 'element[@xmi:type = 'uml:Class']">
         <x:scenario label="Scenario for an internal class">
             <x:context
                 href="../../testData/ePO-core-4.2.0.xml"
-                select="/xmi:XMI/xmi:Extension[1]/elements[1]/element[108]"/>
-            <x:expect label="there is an object entry" test="boolean(/fn:string)"/>
-            <x:expect label="the object entry has correct key" test="/fn:string/@key = 'AwardCriterion'"/>
-            <x:expect label="the object entry has correct value"
-                test="/fn:string/text() = 'http://data.europa.eu/a4g/ontology#AwardCriterion'"/>
+                select="/xmi:XMI/xmi:Extension[1]/elements[1]/element[@name='epo:AwardCriterion']"/>
+            <x:expect label="there is an object entry" test="boolean(/fn:map)"/>
+            <x:expect label="the object entry has correct key" test="/fn:map/@key = 'AwardCriterion'"/>
         </x:scenario>
         <x:scenario label="Scenario for an external class">
             <x:context
                 href="../../testData/ePO-core-4.2.0.xml"
-                select="/xmi:XMI/xmi:Extension[1]/elements[1]/element[90]"/>
-            <x:expect label="there is an object entry" test="boolean(/fn:string)"/>
-            <x:expect label="the object entry has correct key" test="/fn:string/@key = 'adms:Identifier'"/>
-            <x:expect label="the object entry has correct value" test="/fn:string/text() = 'http://www.w3.org/ns/adms#Identifier'"/>
+                select="/xmi:XMI/xmi:Extension[1]/elements[1]/element[@name='adms:Identifier']"/>
+            <x:expect label="there is an object entry" test="boolean(/fn:map)"/>
+            <x:expect label="the object entry has correct key" test="/fn:map/@key = 'adms:Identifier'"/>
         </x:scenario>
         <x:scenario label="Scenario for an excluded class (status == 'proposed')">
             <x:context
                 href="../../testData/ePO-core-4.2.0.xml"
-                select="/xmi:XMI/xmi:Extension[1]/elements[1]/element[180]"/>        
+                select="/xmi:XMI/xmi:Extension[1]/elements[1]/element[@name='epo:Period']"/>        
             <x:expect label="nothing is generated" test="()"/>
         </x:scenario>
     </x:scenario>
 
-    <x:scenario label="Scenario for generating attribute entries of a class - generatePropertiesFromClassAttributes">
+    <x:scenario label="Scenario for class declaration - classDeclaration">
+        <x:scenario label="Scenario for generation of a complete declaration for a class - with attributes and connectors">
+            <x:context
+                href="../../testData/ePO-core-4.2.0.xml"
+                select="/xmi:XMI/xmi:Extension[1]/elements[1]/element[@name='epo:Business']"/>
+            <x:call template="classDeclaration">
+            </x:call>
+            <x:expect label="there is an object entry" test="boolean(/fn:map[@key='Business'])"/>
+            <x:expect label="there is an inner context object"
+                test="boolean(/fn:map[@key='Business']/fn:map[@key='@context'])"/>
+            <x:expect label="there is a correct id in the object entry"
+                test="/fn:map[@key='Business']/fn:string[@key='@id'] = 'http://data.europa.eu/a4g/ontology#Business'"/>
+            <x:expect label="there is a correct number of entries for the associations"
+                test="count(/fn:map[@key='Business']/fn:map[@key='@context']/fn:map) = 3"/>
+            <x:expect label="there is an object for the right association"
+                test="boolean(/fn:map[@key='Business']/fn:map[@key='@context']/fn:map['hasBeneficialOwner'])"/>
+            <x:expect label="there is an object for the right dependency"
+                test="boolean(/fn:map[@key='Business']/fn:map[@key='@context']/fn:map['hasBusinessSize'])"/>
+            <x:expect label="there is an object for the right attribute"
+                test="boolean(/fn:map[@key='Business']/fn:map[@key='@context']/fn:map['isListedCompany'])"/>
+        </x:scenario>
+        <x:scenario label="Scenario for generation of a complete declaration for a class - attributes only">
+            <x:context
+                href="../../testData/ePO-core-4.2.0.xml"
+                select="/xmi:XMI/xmi:Extension[1]/elements[1]/element[@name='epo:ElectronicSignature']"/>
+            <x:call template="classDeclaration"/>
+            <x:expect label="there is an object entry" test="boolean(/fn:map[@key='ElectronicSignature'])"/>
+            <x:expect label="there is an inner context object"
+                test="boolean(/fn:map[@key='ElectronicSignature']/fn:map[@key='@context'])"/>
+            <x:expect label="there is a correct number of entries for the attributes"
+                test="count(/fn:map[@key='ElectronicSignature']/fn:map[@key='@context']/fn:map) = 1"/>
+            <x:expect label="there is an object for the right attribute"
+                test="boolean(/fn:map[@key='ElectronicSignature']/fn:map[@key='@context']/fn:map['description'])"/>
+        </x:scenario>
+        <x:scenario label="Scenario for generation of a complete declaration for a class - connectors only">
+            <x:context
+                href="../../testData/ePO-core-4.2.0.xml"
+                select="/xmi:XMI/xmi:Extension[1]/elements[1]/element[@name='epo:JuryMember']"/>
+            <x:call template="classDeclaration"/>
+            <x:expect label="there is an object entry" test="boolean(/fn:map[@key='JuryMember'])"/>
+            <x:expect label="there is an inner context object"
+                test="boolean(/fn:map[@key='JuryMember']/fn:map[@key='@context'])"/>
+            <x:expect label="there is a correct number of entries for the connectors"
+                test="count(/fn:map[@key='JuryMember']/fn:map[@key='@context']/fn:map) = 1"/>
+            <x:expect label="there is an object for the right connector"
+                test="boolean(/fn:map[@key='JuryMember']/fn:map[@key='@context']/fn:map['playedBy'])"/>
+        </x:scenario>
+        <x:scenario label="Scenario for generation of a simple declaration for a class - no attributes nor connectors">
+            <x:context
+                href="../../testData/ePO-core-4.2.0.xml"
+                select="/xmi:XMI/xmi:Extension[1]/elements[1]/element[@name='epo:Mediator']"/>
+            <x:call template="classDeclaration"/>
+                <x:expect label="there is no object entry" test="not(boolean(/fn:map))"/>
+            <x:expect label="there is a simple term declaration"
+                test="fn:string[@key='Mediator'] = 'http://data.europa.eu/a4g/ontology#Mediator'"/>
+        </x:scenario>
+    </x:scenario>
+
+    <x:scenario label="Scenario for generating attribute entries of a class - classAttributesDeclaration">
         <x:scenario label="Scenario for a class with several attributes">
             <x:context 
                 href="../../testData/ePO-core-4.2.0.xml"
-                select="/xmi:XMI/xmi:Extension[1]/elements[1]/element[170]"/>
-            <x:call template="generatePropertiesFromClassAttributes"/>
+                select="/xmi:XMI/xmi:Extension[1]/elements[1]/element[@name='epo:OpeningTerm']"/>
+            <x:call template="classAttributesDeclaration"/>
             <x:expect label="there are objects for attributes" test="count(/fn:map) = 3"/>
             <x:expect label="there are objects for correct attributes"
                 test="/fn:map/@key = (
-                    'OpeningTerm.hasOpeningDateTime',
-                    'OpeningTerm.hasOpeningDescription',
-                    'OpeningTerm.hasOpeningURL'
+                    'hasOpeningDateTime',
+                    'hasOpeningDescription',
+                    'hasOpeningURL'
             )"/>
         </x:scenario>        
         <x:scenario label="Scenario for an excluded attribute (status == 'proposed')">
             <x:context 
                 href="../../testData/ePO-core-4.2.0.xml"
-                select="/xmi:XMI/xmi:Extension[1]/elements[1]/element[246]"/>
-            <x:call template="generatePropertiesFromClassAttributes"/>
+                select="/xmi:XMI/xmi:Extension[1]/elements[1]/element[@name='epo:Procedure']"/>
+            <x:call template="classAttributesDeclaration"/>
             <x:expect label="there are objects for included attributes" test="count(/fn:map) = 4"/>
             <x:expect label="there are objects for correct attributes"
                 test="/fn:map/@key = (
-                    'Procedure.hasAcceleratedProcedureJustification',
-                    'Procedure.hasMainFeature',
-                    'Procedure.isAccelerated',
-                    'Procedure.isDesignContest'
+                    'hasAcceleratedProcedureJustification',
+                    'hasMainFeature',
+                    'isAccelerated',
+                    'isDesignContest'
             )"/>
             <x:expect label="there is no object for the excluded attribute"
-                test="not(/fn:map[@key = 'Procedure.isJointProcurement'])"/>
+                test="not(/fn:map[@key = 'isJointProcurement'])"/>
         </x:scenario>
         <x:scenario label="Scenario for a class without attributes">
             <x:context 
                 href="../../testData/ePO-core-4.2.0.xml"
-                select="/xmi:XMI/xmi:Extension[1]/elements[1]/element[144]"/>
-            <x:call template="generatePropertiesFromClassAttributes"/>
+                select="/xmi:XMI/xmi:Extension[1]/elements[1]/element[@name='epo:ExclusionGroundsSummary']"/>
+            <x:call template="classAttributesDeclaration"/>
             <x:expect label="there are no objects for attributes" test="()"/>
         </x:scenario>
     </x:scenario>
@@ -75,14 +130,10 @@
         <x:scenario label="Scenario for an internal attribute with a single occurence allowed">
             <x:context 
                 href="../../testData/ePO-core-4.2.0.xml"
-                select="/xmi:XMI/xmi:Extension[1]/elements[1]/element[129]/attributes[1]/attribute[2]"/>
-            <x:call template="attributeGeneration">
-                <x:param name="class"
-                    href="../../testData/ePO-core-4.2.0.xml"
-                    select="/xmi:XMI/xmi:Extension[1]/elements[1]/element[129]"/>
-            </x:call>
+                select="/xmi:XMI/xmi:Extension[1]/elements[1]/element[@name='epo:ContractTerm']/attributes[1]/attribute[@name='epo:hasEOrdering']"/>
+            <x:call template="attributeGeneration"/>
             <x:expect label="there is an object" test="boolean(/fn:map)"/>
-            <x:expect label="the object has correct key" test="/fn:map/@key = 'ContractTerm.hasEOrdering'"/>
+            <x:expect label="the object has correct key" test="/fn:map/@key = 'hasEOrdering'"/>
             <x:expect label="there is an object entry with @id key" test="fn:map/fn:string/@key = '@id'"/>
             <x:expect label="there is an object entry with @type key" test="fn:map/fn:string/@key = '@type'"/>
             <x:expect label="there is no object entry with @container key" test="not(fn:map/fn:string[@key = '@container'])"/>
@@ -90,14 +141,10 @@
         <x:scenario label="Scenario for an internal attribute with multiple occurences allowed">
             <x:context 
                 href="../../testData/ePO-core-4.2.0.xml"
-                select="/xmi:XMI/xmi:Extension[1]/elements[1]/element[120]/attributes[1]/attribute[3]"/>
-            <x:call template="attributeGeneration">
-                <x:param name="class"
-                    href="../../testData/ePO-core-4.2.0.xml"
-                    select="/xmi:XMI/xmi:Extension[1]/elements[1]/element[120]"/>
-            </x:call>
+                select="/xmi:XMI/xmi:Extension[1]/elements[1]/element[@name='epo:ChangeInformation']/attributes[1]/attribute[@name='epo:hasChangeReasonDescription']"/>
+            <x:call template="attributeGeneration"/>
             <x:expect label="there is an object" test="boolean(/fn:map)"/>
-            <x:expect label="the object has correct key" test="/fn:map/@key = 'ChangeInformation.hasChangeReasonDescription'"/>
+            <x:expect label="the object has correct key" test="/fn:map/@key = 'hasChangeReasonDescription'"/>
             <x:expect label="there is an object entry with @id key" test="fn:map/fn:string/@key = '@id'"/>
             <x:expect label="there is an object entry with @type key" test="fn:map/fn:string/@key = '@type'"/>
             <x:expect label="there is an object entry with @container key" test="fn:map/fn:string/@key = '@container'"/>
@@ -105,14 +152,10 @@
         <x:scenario label="Scenario for an external attribute with multiple occurences allowed">
             <x:context 
                 href="../../testData/ePO-core-4.2.0.xml"
-                select="/xmi:XMI/xmi:Extension[1]/elements[1]/element[90]/attributes[1]/attribute[2]"/>
-            <x:call template="attributeGeneration">
-                <x:param name="class"
-                    href="../../testData/ePO-core-4.2.0.xml"
-                    select="/xmi:XMI/xmi:Extension[1]/elements[1]/element[90]"/>
-            </x:call>
+                select="/xmi:XMI/xmi:Extension[1]/elements[1]/element[@name='adms:Identifier']/attributes[1]/attribute[@name='epo:hasScheme']"/>
+            <x:call template="attributeGeneration"/>
             <x:expect label="there is an object" test="boolean(/fn:map)"/>
-            <x:expect label="the object has correct key" test="/fn:map/@key = 'Identifier.hasScheme'"/>
+            <x:expect label="the object has correct key" test="/fn:map/@key = 'hasScheme'"/>
             <x:expect label="there is an object entry with @id key" test="fn:map/fn:string/@key = '@id'"/>
             <x:expect label="there is an object entry with @type key" test="fn:map/fn:string/@key = '@type'"/>
             <x:expect label="there is an object entry with @container key" test="fn:map/fn:string/@key = '@container'"/>


### PR DESCRIPTION
This change brings in a new implementation of the JSON-LD context file generation feature. The new version generates an inner `@context` object for each class instead of using a flat structure with `ClassName.propertyName` key naming convention.

Scope of changes:
* Changed implementation
* Updated unit and functional tests
* Added minor improvements