### PR TITLE
Update format of labels in SHACL artefact (TEDM2O-20)

### DIFF
--- a/src/owl-core-lib/elements-owl-core.xsl
+++ b/src/owl-core-lib/elements-owl-core.xsl
@@ -233,13 +233,6 @@
                         'owl:ObjectProperty'
                     else
                         'rdf:Property'"/>
-
-        <xsl:variable name="name"
-            select="
-                if (boolean($firstAttribute/@name)) then
-                    f:lexicalQNameToWords($firstAttribute/@name, false())
-                else
-                    fn:error(xs:QName('attribute'), concat($firstAttribute/@xmi:idref, ' - Attribute with no name'))"/>
         <xsl:variable name="className" select="$firstAttribute/../../@name" as="xs:string"/>
         <xsl:variable name="isAttributeWithDependencyName"
             select="f:getConnectorByName($firstAttribute/@name, $root)[source/model/@name = $className]"/>

--- a/src/shacl-shape-lib/descriptors-shacl-shape.xsl
+++ b/src/shacl-shape-lib/descriptors-shacl-shape.xsl
@@ -39,7 +39,7 @@
                     <sh:name><xsl:value-of select="f:lexicalQNameToWords($elementName, true())"/></sh:name> 
                 </xsl:when>
                 <xsl:otherwise>
-                     <rdfs:label><xsl:value-of select="f:lexicalQNameToWords($elementName, true())"/></rdfs:label>  
+                     <rdfs:label><xsl:value-of select="f:lexicalQNameToWords($elementName, false())"/></rdfs:label>  
                 </xsl:otherwise>
             </xsl:choose>
         </rdf:Description>

--- a/src/shacl-shape-lib/elements-shacl-shape.xsl
+++ b/src/shacl-shape-lib/elements-shacl-shape.xsl
@@ -259,8 +259,6 @@
     <xsl:template name="attributeRangeShape">
         <xsl:param name="attribute"/>
         <xsl:param name="className"/>
-        <xsl:variable name="attributeURI" select="f:buildURIFromElement($attribute)"/>
-        <xsl:variable name="attributeName" select="f:lexicalQNameToWords($attribute/@name, false())"/>
         <xsl:variable name="attributeType" select="$attribute/properties/@type"/>
         <xsl:variable name="shapePropertyUri"
             select="f:buildPropertyShapeURI($className, $attribute/@name)"/>
@@ -337,8 +335,6 @@
         <xsl:variable name="attributeMultiplicityMax"
             select="f:getAttributeValueToDisplay($attribute/bounds/@upper)"/>
         <xsl:variable name="datatypeURI" select="f:buildURIfromLexicalQName('xsd:integer')"/>
-        <xsl:variable name="attributeURI" select="f:buildURIFromElement($attribute)"/>
-        <xsl:variable name="attributeName" select="f:lexicalQNameToWords($attribute/@name, false())"/>
         <xsl:variable name="shapePropertyUri"
             select="f:buildPropertyShapeURI($className, $attribute/@name)"/>
 

--- a/test/unitTests/test-shacl-shape-lib/test-descriptors-shacl-shape.xspec
+++ b/test/unitTests/test-shacl-shape-lib/test-descriptors-shacl-shape.xspec
@@ -24,7 +24,7 @@
         <x:expect label="there is rdf:Description"
             test="boolean(/rdf:Description[@rdf:about='http:/fake.uri#something'])"
         />
-        <x:expect label="correct label" test="rdf:Description/rdfs:label/text() = 'Dynamic procedure'"/>
+        <x:expect label="correct label" test="rdf:Description/rdfs:label/text() = 'Dynamic Procedure'"/>
         
         
     </x:scenario>


### PR DESCRIPTION
Minor changes related to the formatting of labels in SHACL artefact.

Scope of changes:
* Reverting the format change made to `rdfs:label` based on the agreement with OP.
* Removal of unused variables involving outdated calls to `f:lexicalQNameToWords` and other related variables.
