### PR TITLE
Replace broken hyperlinks for external terms with text elements accompanied by tooltips (TEDM2O-11)

### DIFF
--- a/respec-resources/templates/base.j2
+++ b/respec-resources/templates/base.j2
@@ -13,6 +13,15 @@
 {% set imgRoot = assetsRoot ~ "/img" %}
 {% set shaclRoot = assetsRoot ~ "/shacl" %}
 
+{# Collect compact URIs of all model terms (classes and datatypes) #}
+{%- set all_terms = [] -%}
+{%- for cls in classes -%}
+  {%- set _ = all_terms.append(cls.name) -%}
+{%- endfor -%}
+{%- for dt in datatypes -%}
+  {%- set _ = all_terms.append(dt.scopeduri) -%}
+{%- endfor -%}
+
 {% macro renderFeedbackButton(entity, prop=None) %}
     {% if metadata.openGithubIssue %}    
         {% set _issueTitle = None %}
@@ -151,13 +160,17 @@
                                 </td>
                                 <td>
                                     {% for range in prop.range %}
-                                        {% if range['range_uri'] == range['range_puri'] %}
-                                            <a href="#{{ range['range_label'][language] | replace(' ','') |urlencode | title }}"
-                                            data-toggle="tooltip"
-                                            data-content="{{ range['range_puri'] }}"
-                                            data-placement="right">{{ range['range_label'][language] }}</a>
+                                        {% if range['range_curie'] in all_terms %}
+                                            {% if range['range_uri'] == range['range_puri'] %}
+                                                <a href="#{{ range['range_label'][language] | replace(' ','') |urlencode | title }}"
+                                                data-toggle="tooltip"
+                                                data-content="{{ range['range_puri'] }}"
+                                                data-placement="right">{{ range['range_label'][language] }}</a>
+                                            {% else %}
+                                                <a href="#{{ range['range_label'][language] | replace(' ','') |urlencode | title }}" data-placement="right">{{ range['range_label'][language] }}</a>
+                                            {% endif %}
                                         {% else %}
-                                            <a href="#{{ range['range_label'][language] | replace(' ','') |urlencode | title }}" data-placement="right">{{ range['range_label'][language] }}</a>
+                                                <p title="The term '{{ range['range_curie']}}' is not defined in this document. Please refer to the appropriate module's documentation.">{{ range['range_label'][language] }}</p>
                                         {% endif %}
                                     {% endfor %}
                                 </td>

--- a/src/rspec-json-generate.xsl
+++ b/src/rspec-json-generate.xsl
@@ -19,7 +19,7 @@
     exclude-result-prefixes="xs math xd xsl uml xmi umldi dc fn array map owl rdf rdfs dct f skos"
     version="3.0">
     
-    <xsl:output method="text" media-type="application/json" indent="no"/>
+    <xsl:output method="xml" encoding="UTF-8" omit-xml-declaration="yes"/>
 
     
     <xsl:import href="rspec/rspec-generation.xsl"/>
@@ -92,11 +92,11 @@
             }"/>
 
         <!-- output -->
-        <xsl:value-of
+        <xsl:value-of disable-output-escaping="yes"
             select="serialize($rootMap, map{'method':'json','indent':true()})"
         />
     </xsl:template>
-    
+
  
     <xsl:template name="usedPrefixes" as="array(*)">
         <xsl:variable name="allPrefixNames" select="f:getAllNamespacesUsed(root(.))"/>

--- a/src/rspec/rspec-generation.xsl
+++ b/src/rspec/rspec-generation.xsl
@@ -202,7 +202,10 @@
             for $attribute in $attributes
             return 
                 let $defaultLabel := f:lexicalQNameToWords($attribute/@name, fn:true()),
-                    $attributeLabel := f:getCustomLabelOrDefault($attribute, $defaultLabel)
+                    $attributeLabel := f:getCustomLabelOrDefault($attribute, $defaultLabel),
+                    $attributeRangeCurie := $attribute/properties/@type,
+                    $attributeRangeDefaultLabel := f:lexicalQNameToWords($attributeRangeCurie, fn:true()),
+                    $attributeRangeLabel := f:getCustomLabelOrDefault(root($classElement)//element[@name = $attributeRangeCurie], $attributeRangeDefaultLabel)
                 return map{
                 'uri':   f:buildURIfromLexicalQName($attribute/@name),
                 'name':  string($attribute/@name),
@@ -217,10 +220,10 @@
                 },
                 'range': array{
                 map{
-                'range_uri':  f:buildURIfromLexicalQName($attribute/properties/@type),
-                'range_puri':  f:buildURIfromLexicalQName($attribute/properties/@type),
-                'range_curie': string($attribute/properties/@type),
-                'range_label': map{'en': f:lexicalQNameToWords($attribute/properties/@type, fn:true())}
+                'range_uri':  f:buildURIfromLexicalQName($attributeRangeCurie),
+                'range_puri':  f:buildURIfromLexicalQName($attributeRangeCurie),
+                'range_curie': string($attributeRangeCurie),
+                'range_label': map{'en': $attributeRangeLabel}
                 }
                 },
                 'cardinality': concat($attribute/bounds/@lower, '..', $attribute/bounds/@upper),
@@ -247,7 +250,13 @@
             for $association in $associations
             return
                 let $defaultLabel := f:lexicalQNameToWords($association/target/role/@name, fn:true()),
-                    $associationLabel := f:getCustomLabelOrDefaultFromConnector($association, $defaultLabel)
+                    $associationLabel := f:getCustomLabelOrDefaultFromConnector($association, $defaultLabel),
+                    $associationRangeCurie := $association/target/model/@name,
+                    $associationRangeDefaultLabel := f:lexicalQNameToWords($associationRangeCurie, fn:true()),
+                    $targetClassElement := root($classElement)//element[@name = $associationRangeCurie],
+                    $associationRangeLabel := (if ($targetClassElement) 
+                    then f:getCustomLabelOrDefault($targetClassElement, $associationRangeDefaultLabel) 
+                    else $associationRangeDefaultLabel)
                 return map{
                 'uri':   f:buildURIfromLexicalQName($association/target/role/@name),
                 'name':  string($association/target/role/@name),
@@ -262,10 +271,10 @@
                 },
                 'range': array{
                 map{
-                'range_uri':  f:buildURIfromLexicalQName($association/target/model/@name),
-                'range_puri':  f:buildURIfromLexicalQName($association/target/model/@name),
-                'range_curie': string($association/target/model/@name),
-                'range_label': map{'en': f:lexicalQNameToWords($association/target/model/@name, fn:true())}
+                'range_uri':  f:buildURIfromLexicalQName($associationRangeCurie),
+                'range_puri':  f:buildURIfromLexicalQName($associationRangeCurie),
+                'range_curie': string($associationRangeCurie),
+                'range_label': map{'en': $associationRangeLabel}
                 }
                 },
                 'cardinality': string($association/target/type/@multiplicity),

--- a/test/testData/ePO-core-4.2.0.xml
+++ b/test/testData/ePO-core-4.2.0.xml
@@ -22762,7 +22762,9 @@
 				<project author="lps" version="1.0" phase="1.0" created="2022-04-25 15:41:50" modified="2024-11-11 09:54:58" complexity="1" status="Proposed"/>
 				<code gentype="Java"/>
 				<style appearance="BackColor=-1;BorderColor=-1;BorderWidth=-1;FontColor=-1;VSwimLanes=1;HSwimLanes=1;BorderStyle=0;"/>
-				<tags/>
+				<tags>
+					<tag xmi:id="EAID_2FE57E01_51F2_43af_8E5F_B5E96844D560" name="skos:prefLabel" value="Procedure specific term (custom label)" modelElement="EAID_223696B2_E889_41a8_B53F_E7A5B530FFFD"/>
+				</tags>
 				<xrefs/>
 				<extendedProperties tagged="0" package_name="classes"/>
 				<links>

--- a/test/unitTests/test-rspec/test-rspec-generation.xspec
+++ b/test/unitTests/test-rspec/test-rspec-generation.xspec
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<x:description
+    xmlns:x="http://www.jenitennison.com/xslt/xspec"
+    xmlns:uml="http://www.omg.org/spec/UML/20131001"
+    xmlns:xmi="http://www.omg.org/spec/XMI/20131001"
+    xmlns:fn="http://www.w3.org/2005/xpath-functions"
+    xmlns:map="http://www.w3.org/2005/xpath-functions/map"
+    xmlns:maps="http://www.w3.org/2005/xpath-functions/map"
+    stylesheet="../../../src/rspec-json-generate.xsl">
+
+    <x:scenario label="Scenario for generation of class labels in referenced places">
+        <x:scenario label="Scenario for custom class label">
+            <x:context
+                href="../../testData/ePO-core-4.2.0.xml"
+                select="/xmi:XMI/xmi:Extension[1]/elements[1]/element[@name='epo:Procedure' or @name='epo:OpeningTerm' or @name='epo:ProcedureSpecificTerm']"/>
+            <x:call template="classDetails"/>
+            <x:variable name="expectedLabel" select="'Procedure specific term (custom label)'"/>
+            
+            <x:expect
+                label="correct class label for epo:ProcedureSpecificTerm definition"
+                test="
+                    let $node := ($x:result)[?name = 'epo:ProcedureSpecificTerm']
+                    return $node?label?en
+                "
+                select="$expectedLabel"/>
+            <x:expect
+                label="correct class label in range for epo:isSubjectToProcedureSpecificTerm of epo:Procedure"
+                test="
+                    let $node :=
+                    ($x:result)[?name = 'epo:Procedure'],
+                    $prop :=
+                    ($node?properties?*)
+                        [?name = 'epo:isSubjectToProcedureSpecificTerm']
+                    return
+                    $prop?range?1?range_label?en
+                "
+                select="$expectedLabel"/>
+            <x:expect
+                label="correct class label for parent of epo:OpeningTerm"
+                test="
+                    let $node :=
+                    ($x:result)[?name = 'epo:OpeningTerm'],
+                    $parent :=
+                    ($node?parents?*)
+                        [?name = 'epo:ProcedureSpecificTerm']
+                    return
+                    $parent?label?en
+                "
+                select="$expectedLabel"/>
+        </x:scenario>
+        <x:scenario label="Scenario for standard class label">
+            <x:context
+                href="../../testData/ePO-core-4.2.0.xml"
+                select="/xmi:XMI/xmi:Extension[1]/elements[1]/element[@name='epo:Candidate' or @name='epo:OfferingParty' or @name='epo:ExpressionOfInterest']"/>
+            <x:call template="classDetails"/>
+            <x:variable name="expectedLabel" select="'Offering party'"/>
+            
+            <x:expect
+                label="correct class label for epo:OfferingParty definition"
+                test="
+                    let $node := ($x:result)[?name = 'epo:OfferingParty']
+                    return $node?label?en
+                "
+                select="$expectedLabel"/>
+            <x:expect
+                label="correct class label in range for epo:specifiesEconomicOperator of epo:ExpressionOfInterest"
+                test="
+                    let $node :=
+                    ($x:result)[?name = 'epo:ExpressionOfInterest'],
+                    $prop :=
+                    ($node?properties?*)
+                        [?name = 'epo:specifiesEconomicOperator']
+                    return
+                    $prop?range?1?range_label?en
+                "
+                select="$expectedLabel"/>
+            <x:expect
+                label="correct class label for parent of epo:Candidate"
+                test="
+                    let $node :=
+                    ($x:result)[?name = 'epo:Candidate'],
+                    $parent :=
+                    ($node?parents?*)
+                        [?name = 'epo:OfferingParty']
+                    return
+                    $parent?label?en
+                "
+                select="$expectedLabel"/>
+        </x:scenario>
+    </x:scenario>
+</x:description>


### PR DESCRIPTION
The change addresses broken hyperlinks issue in the ReSpec documentation. The generation logic has been updated to identify whether a referenced term is defined in the model or only referenced. A term reference is presented as a hyperlink to a document section only if the term is defined in the document. Otherwise, the reference is rendered as plain text with a tooltip informing users of this fact and guiding them to check the documentation of other modules.
