### PR TITLE
Enhance JSON-LD context generation to support multiple outgoing connectors that share the same target-end name (TEDM2O-7)

### DIFF
--- a/src/common/utils.xsl
+++ b/src/common/utils.xsl
@@ -555,7 +555,7 @@
     <xd:doc>
         <xd:desc>
             Determines if multiple values for the relation range are allowed by
-            checking the connector multiplicity.
+            checking the connector multiplicity. Supports multiplicity shorthands like '1' and using '+' to indicate a cardinality of multiple values.
         </xd:desc>
         <xd:param name="multiplicity"/>
     </xd:doc>
@@ -563,11 +563,16 @@
         <xsl:param name="multiplicity"/>
         <xsl:variable name="multiplicityString"
             select="f:normalizeMultiplicity($multiplicity)"/>
-        <xsl:variable name="targetMaxMultiplicity"
-            select="fn:substring-after($multiplicityString, '..')"/>
-        <xsl:sequence
-            select="boolean($targetMaxMultiplicity) and not($targetMaxMultiplicity = ('', '0', '1'))"
-        />
+        <xsl:variable name="maxRaw"
+            select="if (contains($multiplicityString, '..'))
+                    then substring-after($multiplicityString, '..')
+                    else $multiplicityString"/>
+        <xsl:sequence select="
+            if ($maxRaw = '*' or $maxRaw = '+' or number($maxRaw) > 1) then
+                fn:true()
+            else
+                fn:false()
+        "/>
     </xsl:function>
 
     <xd:doc>

--- a/src/jsonld-context-lib/connectors-jsonld-context.xsl
+++ b/src/jsonld-context-lib/connectors-jsonld-context.xsl
@@ -38,28 +38,39 @@
             select="('Association', 'Dependency')"/>
         <xsl:variable name="relations"
             select="f:getOutgoingRelationsByType($class, $supportedConnTypes)"/>
-        <xsl:for-each-group select="$relations//relation" group-by="@name">
-            <xsl:variable name="relation" select="current-group()[1]"/>
-            <xsl:variable name="multiplicity"
-              select="if (some $r in current-group() satisfies (f:areMultipleValuesForRelationRangeAllowed($r/@multiplicity)))
-                      then '+'
-                      else '1'"/>
-            <xsl:variable name="connector"
-                select="f:getConnectorByIdRef($relation/@connectorIdRef, root())"/>
-            <xsl:if test="not(f:isExcludedByStatus($connector))">
-                <xsl:if test="$relation/source/@type != 'ProxyConnector'
-                    and $relation/target/@type != 'ProxyConnector'">
-                    <xsl:variable name="connectorRoleName" select="$relation/@name"/>
-                    <xsl:if
-                        test="$generateReusedConceptsJSONLDcontext 
-                        or f:getPrefix($connectorRoleName) = $includedPrefixesList">
-                        <xsl:call-template name="relationGeneration">
-                            <xsl:with-param name="relation" select="$relation"/>
-                            <xsl:with-param name="multiplicityOverride" select="$multiplicity"/>
-                        </xsl:call-template>
-                    </xsl:if>
+
+        <!-- Filter relations before grouping -->
+        <xsl:variable name="filteredRelations" as="element(relation)*">
+            <xsl:for-each select="$relations//relation">
+                <xsl:variable name="connector"
+                    select="f:getConnectorByIdRef(@connectorIdRef, root())"/>
+                <xsl:if test="
+                    not(f:isExcludedByStatus($connector))
+                    and @name
+                    and (source/@type != 'ProxyConnector')
+                    and (target/@type != 'ProxyConnector')
+                    and ($generateReusedConceptsJSONLDcontext 
+                        or f:getPrefix(@name) = $includedPrefixesList)
+                ">
+                    <xsl:sequence select="."/>
                 </xsl:if>
-            </xsl:if>
+            </xsl:for-each>
+        </xsl:variable>
+
+        <xsl:for-each-group select="$filteredRelations" group-by="@name">
+            <xsl:variable name="group" select="current-group()"/>
+            <xsl:variable name="relation" select="$group[1]"/>
+            <xsl:variable name="multiplicity"
+            select="
+                if (some $r in $group
+                    satisfies f:areMultipleValuesForRelationRangeAllowed($r/@multiplicity))
+                then '+'
+                else '1'
+            "/>
+            <xsl:call-template name="relationGeneration">
+                <xsl:with-param name="relation" select="$relation"/>
+                <xsl:with-param name="multiplicityOverride" select="$multiplicity"/>
+            </xsl:call-template>
         </xsl:for-each-group>
     </xsl:template>
 

--- a/src/jsonld-context-lib/connectors-jsonld-context.xsl
+++ b/src/jsonld-context-lib/connectors-jsonld-context.xsl
@@ -23,7 +23,13 @@
     <xd:doc>
         <xd:desc>
             Generates node objects for associations and dependencies of the
-            given class that are not excluded based on their status or origin.
+            given class that are not excluded based on their status or origin. 
+
+            The template supports multiple outgoing connectors (associations and
+            dependencies) sharing the same target-end name. For such cases, it
+            generates a single entry in the context with the appropriate
+            `@container` entry if the cardinality of any of the connectors
+            allows multiple values.
         </xd:desc>
     </xd:doc>
     <xsl:template name="classConnectorsDeclaration">
@@ -32,35 +38,51 @@
             select="('Association', 'Dependency')"/>
         <xsl:variable name="relations"
             select="f:getOutgoingRelationsByType($class, $supportedConnTypes)"/>
-        <xsl:for-each select="$relations//relation">
-                <xsl:variable name="relation" select="."/>
-                <xsl:variable name="connector"
-                    select="f:getConnectorByIdRef($relation/@connectorIdRef, root())"/>
-                <xsl:if test="not(f:isExcludedByStatus($connector))">
-                    <xsl:if test="$relation/source/@type != 'ProxyConnector'
-                        and $relation/target/@type != 'ProxyConnector'">
-                        <xsl:variable name="connectorRoleName" select="$relation/@name"/>
-                        <xsl:if
-                            test="$generateReusedConceptsJSONLDcontext 
-                            or f:getPrefix($connectorRoleName) = $includedPrefixesList">
-                            <xsl:call-template name="relationGeneration">
-                                <xsl:with-param name="relation" select="$relation"/>
-                            </xsl:call-template>
-                        </xsl:if>
+        <xsl:for-each-group select="$relations//relation" group-by="@name">
+            <xsl:variable name="relation" select="current-group()[1]"/>
+            <xsl:variable name="multiplicity"
+              select="if (some $r in current-group() satisfies (f:areMultipleValuesForRelationRangeAllowed($r/@multiplicity)))
+                      then '+'
+                      else '1'"/>
+            <xsl:variable name="connector"
+                select="f:getConnectorByIdRef($relation/@connectorIdRef, root())"/>
+            <xsl:if test="not(f:isExcludedByStatus($connector))">
+                <xsl:if test="$relation/source/@type != 'ProxyConnector'
+                    and $relation/target/@type != 'ProxyConnector'">
+                    <xsl:variable name="connectorRoleName" select="$relation/@name"/>
+                    <xsl:if
+                        test="$generateReusedConceptsJSONLDcontext 
+                        or f:getPrefix($connectorRoleName) = $includedPrefixesList">
+                        <xsl:call-template name="relationGeneration">
+                            <xsl:with-param name="relation" select="$relation"/>
+                            <xsl:with-param name="multiplicityOverride" select="$multiplicity"/>
+                        </xsl:call-template>
                     </xsl:if>
                 </xsl:if>
-        </xsl:for-each>
+            </xsl:if>
+        </xsl:for-each-group>
     </xsl:template>
 
     <xd:doc>
         <xd:desc>
             Generates a node object for the relation. Includes the relation URI
             mapping, type, and container information.
+
+            Accepts the optional `multiplicityOverride` parameter to override
+            the relation's multiplicity.
         </xd:desc>
         <xd:param name="relation"/>
     </xd:doc>
     <xsl:template name="relationGeneration">
         <xsl:param name="relation"/>
+        <xsl:param name="multiplicityOverride" select="''"/>
+
+        <xsl:variable name="effectiveMultiplicity"
+            select="if (normalize-space($multiplicityOverride) != '')
+                    then $multiplicityOverride
+                    else $relation/@multiplicity"
+        />
+
         <xsl:variable name="relCurie" select="$relation/@name"/>
         <xsl:variable name="relName" select="f:getLocalSegment($relCurie)"/>
         <fn:map key="{$relName}">
@@ -69,7 +91,7 @@
             </xsl:call-template>
             <xsl:call-template name="relationTypeDeclaration"/>
             <xsl:call-template name="relationContainerDeclaration">
-                <xsl:with-param name="multiplicity" select="$relation/@multiplicity"/>
+                <xsl:with-param name="multiplicity" select="$effectiveMultiplicity"/>
             </xsl:call-template>
         </fn:map>
     </xsl:template>

--- a/test/testData/ePO-core-4.2.0.xml
+++ b/test/testData/ePO-core-4.2.0.xml
@@ -20791,6 +20791,7 @@
 					<Dependency xmi:id="EAID_12A5A0C6_97F3_4362_97F5_2EACA8AA8D1B" start="EAID_40588AD6_810D_4fd6_BA64_B05755E636F2" end="EAID_B7C0137B_3C6D_42f7_AB51_FA49B0F7E63B"/>
 					<Association xmi:id="EAID_A01E8ADE_1698_4353_BEDB_63334B745ECB" start="EAID_40588AD6_810D_4fd6_BA64_B05755E636F2" end="EAID_F5B54CD5_45A5_4220_A1F4_9F1CD0DD9969"/>
 					<Association xmi:id="EAID_A02EFC84_74F8_415f_B4C7_BC3E17610EF7" start="EAID_40588AD6_810D_4fd6_BA64_B05755E636F2" end="EAID_B52CB5AD_2F7E_4e03_AFA8_D5DCED9D61C7"/>
+					<Association xmi:id="EAID_A02EFC84_74F8_415f_B4C7_BC3E17610EF8" start="EAID_40588AD6_810D_4fd6_BA64_B05755E636F2" end="EAID_29678A10_6473_461a_BE84_76269B5BBD68"/>
 					<Dependency xmi:id="EAID_B0D4CDC5_3F31_4f44_9C9D_C9C33A874154" start="EAID_40588AD6_810D_4fd6_BA64_B05755E636F2" end="EAID_1D435754_B2BA_42ed_805E_C8B5A8985BC5"/>
 					<Dependency xmi:id="EAID_BA97DF04_90AD_4153_8BC2_8F80AD12DA02" start="EAID_40588AD6_810D_4fd6_BA64_B05755E636F2" end="EAID_9700E0F6_A1F2_4c3e_9848_ECC8B70AFE82"/>
 					<Generalization xmi:id="EAID_D62CD782_93C6_480f_BE3B_872E1A0882C0" start="EAID_40588AD6_810D_4fd6_BA64_B05755E636F2" end="EAID_F7EC5BAF_BF10_4e4d_BAF3_ED8B1330B5E6"/>
@@ -25563,6 +25564,7 @@
 					<NoteLink xmi:id="EAID_D1765221_81FB_4316_892D_E974CE455005" start="EAID_7E2E06EA_022C_468e_B46C_17C2AA282DCD" end="EAID_29678A10_6473_461a_BE84_76269B5BBD68"/>
 					<NoteLink xmi:id="EAID_DA42655D_7F73_4abf_87D3_800074047096" start="EAID_59A6B46E_8FBB_4614_8AD5_D1EE6AB3905C" end="EAID_29678A10_6473_461a_BE84_76269B5BBD68"/>
 					<NoteLink xmi:id="EAID_FABCE042_BD3F_455b_AA89_4B890DB85CB2" start="EAID_EB39EE3E_49DD_4ae3_9836_5FA1C8C8F79B" end="EAID_29678A10_6473_461a_BE84_76269B5BBD68"/>
+					<Association xmi:id="EAID_A02EFC84_74F8_415f_B4C7_BC3E17610EF8" start="EAID_40588AD6_810D_4fd6_BA64_B05755E636F2" end="EAID_29678A10_6473_461a_BE84_76269B5BBD68"/>
 				</links>
 			</element>
 			<element xmi:idref="EAID_2424C22E_B54F_4b6f_BA47_E78DE21C76DE" xmi:type="uml:Class" name="locn:Geometry" scope="public">
@@ -31638,7 +31640,7 @@
 				<target xmi:idref="EAID_B52CB5AD_2F7E_4e03_AFA8_D5DCED9D61C7">
 					<model ea_localid="87" type="Class" name="dct:Location"/>
 					<role name="epo:definesSpecificPlaceOfPerformance" visibility="Public" targetScope="instance"/>
-					<type multiplicity="0..*" aggregation="none" containment="Unspecified"/>
+					<type multiplicity="0..1" aggregation="none" containment="Unspecified"/>
 					<constraints/>
 					<modifiers isOrdered="false" changeable="none" isNavigable="true"/>
 					<style value="Union=0;Derived=0;AllowDuplicates=0;Owned=0;Navigable=Navigable;"/>
@@ -31652,7 +31654,7 @@
 				<parameterSubstitutions/>
 				<documentation value="Relation indicating a ContractTerm has a specific place of performance."/>
 				<appearance linemode="3" linecolor="-1" linewidth="0" seqno="0" headStyle="0" lineStyle="0"/>
-				<labels rb="0..*" rt="+epo:definesSpecificPlaceOfPerformance"/>
+				<labels rb="0..1" rt="+epo:definesSpecificPlaceOfPerformance"/>
 				<extendedProperties virtualInheritance="0"/>
 				<style/>
 				<xrefs/>
@@ -39824,7 +39826,7 @@
 				</source>
 				<target xmi:idref="EAID_BF1B4E2A_7D4A_4247_8B45_5AD2427938E3">
 					<model ea_localid="230" type="Enumeration" name="at-voc:environmental-impact"/>
-					<role name="epo:fulfillsEnvironmentalRequirement" visibility="Public" targetScope="instance"/>
+					<role name="epo:fulfillsRequirement" visibility="Public" targetScope="instance"/>
 					<type multiplicity="0..*" aggregation="none" containment="Unspecified"/>
 					<constraints/>
 					<modifiers isOrdered="false" changeable="none" isNavigable="true"/>
@@ -53325,6 +53327,40 @@
 				<documentation/>
 				<appearance linemode="3" linecolor="-1" linewidth="0" seqno="0" headStyle="0" lineStyle="0"/>
 				<labels/>
+				<extendedProperties virtualInheritance="0"/>
+				<style/>
+				<xrefs/>
+				<tags/>
+			</connector>
+			<connector xmi:idref="EAID_A02EFC84_74F8_415f_B4C7_BC3E17610EF8">
+				<source xmi:idref="EAID_40588AD6_810D_4fd6_BA64_B05755E636F2">
+					<model ea_localid="49" type="Class" name="epo:ContractTerm"/>
+					<role visibility="Public" targetScope="instance"/>
+					<type aggregation="none" containment="Unspecified"/>
+					<constraints/>
+					<modifiers isOrdered="false" changeable="none" isNavigable="false"/>
+					<style value="Union=0;Derived=0;AllowDuplicates=0;Owned=0;Navigable=Non-Navigable;"/>
+					<documentation/>
+					<xrefs/>
+					<tags/>
+				</source>
+				<target xmi:idref="EAID_29678A10_6473_461a_BE84_76269B5BBD68">
+					<model ea_localid="33" type="Class" name="locn:Address"/>
+					<role name="epo:definesSpecificPlaceOfPerformance" visibility="Public" targetScope="instance"/>
+					<type multiplicity="0..1" aggregation="none" containment="Unspecified"/>
+					<constraints/>
+					<modifiers isOrdered="false" changeable="none" isNavigable="true"/>
+					<style value="Union=0;Derived=0;AllowDuplicates=0;Owned=0;Navigable=Navigable;"/>
+					<documentation/>
+					<xrefs/>
+				</target>
+				<model ea_localid="204"/>
+				<properties ea_type="Association" direction="Source -&gt; Destination"/>
+				<modifiers isRoot="false" isLeaf="false"/>
+				<parameterSubstitutions/>
+				<documentation value="Relation indicating a ContractTerm has a specific place of performance."/>
+				<appearance linemode="3" linecolor="-1" linewidth="0" seqno="0" headStyle="0" lineStyle="0"/>
+				<labels rb="0..*" rt="+epo:definesSpecificPlaceOfPerformance"/>
 				<extendedProperties virtualInheritance="0"/>
 				<style/>
 				<xrefs/>

--- a/test/unitTests/test-common/test-utils.xspec
+++ b/test/unitTests/test-common/test-utils.xspec
@@ -525,4 +525,64 @@
         
     </x:scenario>
 
+    <x:scenario label="Scenario for f:areMultipleValuesForRelationRangeAllowed">
+        <x:scenario label="Multiplicity '*' allows multiple values">
+            <x:call function="f:areMultipleValuesForRelationRangeAllowed">
+                <x:param name="multiplicity" select="'+'"/>
+            </x:call>
+            <x:expect label="returns true" select="fn:true()"/>
+        </x:scenario>
+
+        <x:scenario label="Multiplicity '1' does NOT allow multiple values">
+            <x:call function="f:areMultipleValuesForRelationRangeAllowed">
+                <x:param name="multiplicity" select="'1'"/>
+            </x:call>
+            <x:expect label="returns false" select="fn:false()"/>
+        </x:scenario>
+
+        <x:scenario label="Multiplicity '0' does NOT allow multiple values">
+            <x:call function="f:areMultipleValuesForRelationRangeAllowed">
+                <x:param name="multiplicity" select="'0'"/>
+            </x:call>
+            <x:expect label="returns false" select="fn:false()"/>
+        </x:scenario>
+
+        <x:scenario label="Multiplicity '0..*' allows multiple values">
+            <x:call function="f:areMultipleValuesForRelationRangeAllowed">
+                <x:param name="multiplicity" select="'0..*'"/>
+            </x:call>
+            <x:expect label="returns true" select="fn:true()"/>
+        </x:scenario>
+
+        <x:scenario label="Multiplicity '1..*' allows multiple values">
+            <x:call function="f:areMultipleValuesForRelationRangeAllowed">
+                <x:param name="multiplicity" select="'1..*'"/>
+            </x:call>
+            <x:expect label="returns true" select="fn:true()"/>
+        </x:scenario>
+
+        <x:scenario label="Multiplicity '0..1' does NOT allow multiple values">
+            <x:call function="f:areMultipleValuesForRelationRangeAllowed">
+                <x:param name="multiplicity" select="'0..1'"/>
+            </x:call>
+            <x:expect label="returns false" select="fn:false()"/>
+        </x:scenario>
+
+        <x:scenario label="Multiplicity '1..2' allows multiple values">
+            <x:call function="f:areMultipleValuesForRelationRangeAllowed">
+                <x:param name="multiplicity" select="'1..2'"/>
+            </x:call>
+            <x:expect label="returns true" select="fn:true()"/>
+        </x:scenario>
+
+        <x:scenario label="Multiplicity '1..1' does NOT allow multiple values">
+            <x:call function="f:areMultipleValuesForRelationRangeAllowed">
+                <x:param name="multiplicity" select="'1..1'"/>
+            </x:call>
+            <x:expect label="returns false" select="fn:false()"/>
+        </x:scenario>
+
+    </x:scenario>
+
+
 </x:description>

--- a/test/unitTests/test-jsonld-context-lib/test-connectors-jsonld-context.xspec
+++ b/test/unitTests/test-jsonld-context-lib/test-connectors-jsonld-context.xspec
@@ -17,6 +17,34 @@
             <x:expect label="there is an object for the right association"
                 test="boolean(fn:map['comprisesAwardOutcome'])"/>
         </x:scenario>
+        <x:scenario label="Scenario for multiple dependencies with the same target-end name">
+            <!-- 
+                This scenario targets a single class that has two outgoing
+                dependencies. The cardinality of both dependencies allows
+                multiple occurences.
+            -->
+            <x:context
+                href="../../testData/ePO-core-4.2.0.xml"
+                select="/xmi:XMI/xmi:Extension[1]/connectors[1]/connector[source[1]/model[1]/@name = 'epo:GreenProcurement'] | /xmi:XMI/xmi:Extension[1]/elements[1]/element[@name='epo:GreenProcurement']"/>
+            <x:call template="classConnectorsDeclaration"/>
+            <x:expect label="there is exactly one object entry for multiple occurences of a property" test="count(/fn:map[@key= 'fulfillsRequirement']) = 1"/>
+            <x:expect label="the property declaration has the correct @container value"
+                test="//fn:map[@key= 'fulfillsRequirement']/fn:string[@key='@container']/text() = '@set'"/>
+        </x:scenario>
+        <x:scenario label="Scenario for multiple associations with the same target-end name">
+            <!--
+                This scenario targets a single class that has two outgoing
+                associations. The cardinality of both associations does not
+                allow multiple occurrences.
+            -->
+            <x:context
+                href="../../testData/ePO-core-4.2.0.xml"
+                select="/xmi:XMI/xmi:Extension[1]/connectors[1]/connector[source[1]/model[1]/@name = 'epo:ContractTerm'] | /xmi:XMI/xmi:Extension[1]/elements[1]/element[@name='epo:ContractTerm']"/>
+            <x:call template="classConnectorsDeclaration"/>
+            <x:expect label="there is exactly one object entry for multiple occurences of a property" test="count(/fn:map[@key= 'definesSpecificPlaceOfPerformance']) = 1"/>
+            <x:expect label="cardinality is interpreted correctly and there is no @container entry"
+                test="not(boolean(//fn:map[@key= 'definesSpecificPlaceOfPerformance']/fn:string[@key='@container']))"/>
+        </x:scenario>
         <x:scenario label="Scenario for a class without connectors">
             <x:context
                 href="../../testData/ePO-core-4.2.0.xml"


### PR DESCRIPTION
The change brings in support for multiple targets (classes and enumerations) linked to a single source class through connectors that share the same target-end name. It addresses such cases as the one described in https://github.com/OP-TED/ePO/issues/806.
The related case of the same property name (`epo:fulfillsRequirement`) in the test data was reverted to its original form. In addition, another example was crafted for association, namely `epo:ContractTerm -[epo:definesSpecificPlaceOfPerformance]-> locn:Address`, to demonstrate that the enhancement supports both UML dependencies and associations. Existing tests have been updated and new ones were implemented to verify the enhancement.