### PR TITLE
Restore autogenerated issued date for RDF artefacts and unify use of the issuedDate parameter across RDF and ReSpec artefacts (TEDM2O-11)

### DIFF
--- a/respec-resources/templates/base.j2
+++ b/respec-resources/templates/base.j2
@@ -269,7 +269,7 @@
       edDraftURI: "{{metadata.navigation.self}}",
       latestVersion: "{{metadata.navigation.prev}}",
       specStatus: "base",
-      publishDate: "{{ metadata.issued }}",
+      publishDate: "{{ config.issuedDate }}",
       editors: myeditors,
       authors: myauthors,
       github: "{{metadata.github}}",
@@ -408,8 +408,8 @@
         It is recommended to indicate the <a href="https://www.w3.org/2021/Process-20211102/#maturity-levels">maturity levels</a> of the specification.
     </p>
     <p>
-        {% if metadata.status and metadata.issued %}
-            This application profile has the status <i>{{ metadata.status }}</i> and has been published on {{ metadata.issued }}.
+        {% if metadata.status and config.issuedDate %}
+            This application profile has the status <i>{{ metadata.status }}</i> and has been published on {{ config.issuedDate }}.
         {% endif %}
     </p>
     <p>

--- a/src/owl-core.xsl
+++ b/src/owl-core.xsl
@@ -89,7 +89,7 @@
             <xsl:for-each select="1 to array:size($seeAlsoArray)">
                 <rdfs:seeAlso rdf:resource="{$seeAlsoArray(.)}"/>
             </xsl:for-each>
-            <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#date"><xsl:value-of select="f:getMetadataValue('issuedDate')"/></dct:issued>
+            <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#date"><xsl:value-of select="$issuedDate"/></dct:issued>
             <dct:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date"><xsl:value-of select="f:getMetadataValue('createdDate')"/></dct:created>
             <owl:versionInfo><xsl:value-of select="f:getMetadataValue('versionInfo')"/></owl:versionInfo>   
             <owl:incompatibleWith><xsl:value-of select="f:getMetadataValue('incompatibleWith')"/></owl:incompatibleWith>

--- a/src/owl-restrictions.xsl
+++ b/src/owl-restrictions.xsl
@@ -81,7 +81,7 @@
                 <rdfs:seeAlso rdf:resource="{$seeAlsoArray(.)}"/>
             </xsl:for-each>
 
-            <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#date"><xsl:value-of select="f:getMetadataValue('issuedDate')"/></dct:issued>
+            <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#date"><xsl:value-of select="$issuedDate"/></dct:issued>
             <dct:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date"><xsl:value-of select="f:getMetadataValue('createdDate')"/></dct:created>
             <owl:versionInfo><xsl:value-of select="f:getMetadataValue('versionInfo')"/></owl:versionInfo>   
             <owl:incompatibleWith><xsl:value-of select="f:getMetadataValue('incompatibleWith')"/></owl:incompatibleWith>

--- a/src/rspec-cfg-json-generate.xsl
+++ b/src/rspec-cfg-json-generate.xsl
@@ -34,7 +34,8 @@
                     'classReferenceRespecLabel': string($classReferenceRespecLabel),
                     'showReferencesInRespec': boolean($showReferencesInRespec),
                     'mandatoryStatusTagName': string($mandatoryStatusTagName),
-                    'usageNoteTagName': string($usageNoteTagName)
+                    'usageNoteTagName': string($usageNoteTagName),
+                    'issuedDate': string($issuedDate)
                 }
             }"/>
 

--- a/src/shacl-shapes.xsl
+++ b/src/shacl-shapes.xsl
@@ -85,7 +85,7 @@
             <xsl:for-each select="1 to array:size($seeAlsoArray)">
                 <rdfs:seeAlso rdf:resource="{$seeAlsoArray(.)}"/>
             </xsl:for-each>
-            <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#date"><xsl:value-of select="f:getMetadataValue('issuedDate')"/></dct:issued>
+            <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#date"><xsl:value-of select="$issuedDate"/></dct:issued>
             <dct:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date"><xsl:value-of select="f:getMetadataValue('createdDate')"/></dct:created>
             <owl:versionInfo><xsl:value-of select="f:getMetadataValue('versionInfo')"/></owl:versionInfo>   
             <owl:incompatibleWith><xsl:value-of select="f:getMetadataValue('incompatibleWith')"/></owl:incompatibleWith>

--- a/test/ePO-default-config/config-parameters.xsl
+++ b/test/ePO-default-config/config-parameters.xsl
@@ -5,6 +5,7 @@
     xmlns:dct="http://purl.org/dc/terms/" xmlns:fn="http://www.w3.org/2005/xpath-functions"
     xmlns:functx="http://www.functx.com" xmlns:owl="http://www.w3.org/2002/07/owl#"
     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:vann="http://purl.org/vocab/vann/"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
     version="3.0">
 
     <xd:doc scope="stylesheet">
@@ -154,6 +155,11 @@
 
     <xsl:variable name="moduleReference" select="'core'"/>
 
- 
+    <!-- Date used for dct:issued property in the RDF artefacts and ReSpec
+    documentation. Defaults to the currrent date.
+    A fixed date can be set as follows:
+    select="xs:date('2024-01-01')"
+    -->
+    <xsl:variable name="issuedDate" select="format-date(current-date(),'[Y0001]-[M01]-[D01]')"/>
 
 </xsl:stylesheet>

--- a/test/ePO-default-config/metadata.json
+++ b/test/ePO-default-config/metadata.json
@@ -20,7 +20,6 @@
             "https://op.europa.eu/en/web/eu-vocabularies/e-procurement",
             "https://docs.ted.europa.eu/EPO/latest/index.html"
         ],
-        "issuedDate": "2025-09-04",
         "createdDate": "2025-09-04",
         "incompatibleWith": "2.1.0",
         "versionInfo": "3.1.0",
@@ -70,7 +69,6 @@
             "columnLabel": "Feedback",
             "buttonLabel": "Report an issue or share feedback"
         },
-        "issued": "2025-09-04",
         "license": "CC BY 4.0",
         "navigation": {
             "next": "",


### PR DESCRIPTION
Scope of changes:
* Removed the `issued` and `issuedDate` metadata properties from metadata.json.
* Restored the `issuedDate` config parameter in config-parameters.xsl and set its default to the current date.
* Updated config JSON generation to include `issuedDate`, using the restored parameter.
* Modified the ReSpec template to consume `issuedDate` from the ReSpec config JSON.
* Updated all RDF artefact generation scripts to use the `issuedDate` config parameter (restoring former behaviour).