### PR TITLE
Extend AsciiDoc glossary generation to support status-based filtering

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -532,7 +532,20 @@ generate-asciidoc-glossary:
 			OUTPUT_FOLDER_PATH=${OUTPUT_FOLDER_PATH} ; \
 		MODEL_DATA_JSON_PATH=$$(find "${OUTPUT_FOLDER_PATH}" -maxdepth 1 -name '*_respec.json' | head -n 1); \
 		GEN_MODEL_DATA_JSON=1; \
+	else \
+		echo "Creating temporary copy of existing model data JSON..."; \
+		tmp_file=$$(mktemp --suffix=".json"); \
+		cp "${MODEL_DATA_JSON_PATH}" "$$tmp_file"; \
+		MODEL_DATA_JSON_PATH="$$tmp_file"; \
 	fi; \
+	\
+	# generate a respec config JSON file \
+	echo "Generating a config JSON file ..."; \
+	$(MAKE) respec-cfg-json XMI_INPUT_FILE_PATH=${XMI_INPUT_FILE_PATH} OUTPUT_FOLDER_PATH=${OUTPUT_FOLDER_PATH} ; \
+	# merge the config and data JSON files into a single JSON file to be used \
+	# for generating the asciidoc document \
+	merged_json=$$(mktemp --suffix=".json"); \
+	$(JQ) -s 'reduce .[] as $$item ({}; . * $$item)' ${MODEL_DATA_JSON_PATH} ${RESPEC_CFG_JSON_PATH} > $$merged_json; \
 	\
 	## get value of a config parameter from the correct XSL config file \
 	generate_reused_concepts=$$( \
@@ -555,7 +568,7 @@ generate-asciidoc-glossary:
 	\
 	## run jinja to generate the respec document \
 	source model2owl-venv/bin/activate; \
-	jinja -d ${MODEL_DATA_JSON_PATH} \
+	jinja -d $$merged_json \
 		-D generate_reused_concepts $$generate_reused_concepts \
 		glossary-resources/asciidoc-glossary.j2 \
 		-o ${OUTPUT_GLOSSARY_PATH}/${XMI_INPUT_FILENAME_WITHOUT_EXTENSION}_glossary.adoc ; \

--- a/glossary-resources/asciidoc-glossary.j2
+++ b/glossary-resources/asciidoc-glossary.j2
@@ -46,12 +46,26 @@ tables covering classes, datatype properties (attributes) and object properties
 
 
 {# build helper structure for properties #}
-{# Step 1: collect all properties in a flat list #}
+{#- Step 1: collect properties that are not filtered out by status in a flat list -#}
 {%- set all_props = [] -%}
 {%- for cls in classes -%}
-  {%- for prop in cls.properties -%}
-    {%- set _ = all_props.append(prop) -%}
-  {%- endfor -%}
+  {%- set effective_cls_status =
+    cls.tags[config.statusProperty]
+    if config.statusProperty in cls.tags
+    else config.unspecifiedStatusInterpretation
+  -%}
+  {%- if effective_cls_status not in config.excludedElementStatusesList -%}
+    {%- for prop in cls.properties -%}
+      {%- set effective_prop_status =
+        prop.tags[config.statusProperty]
+        if config.statusProperty in prop.tags
+        else config.unspecifiedStatusInterpretation
+      -%}
+      {%- if effective_prop_status not in config.excludedElementStatusesList -%}
+        {%- set _ = all_props.append(prop) -%}
+      {%- endif -%}
+    {%- endfor -%}
+  {%- endif -%}
 {%- endfor -%}
 {# Step 2: get unique property names #}
 {%- set prop_names = [] -%}
@@ -96,11 +110,18 @@ tables covering classes, datatype properties (attributes) and object properties
 |===
 | Class name | Definition
 {% for cls in classes %}
-  {% if generate_reused_concepts_ or cls.rawTags['class-usage-scope'] == "main" %}
-  {% if cls.classType == "definition" %}
-  | {{ cls.name }} | {{ passthrough_if_external_concept(cls.description.en) }}
-  {% endif %}
-  {% endif %}
+  {%- set effective_elem_status =
+    cls.tags[config.statusProperty]
+    if config.statusProperty in cls.tags
+    else config.unspecifiedStatusInterpretation
+  -%}
+  {%- if effective_elem_status not in config.excludedElementStatusesList -%}
+    {% if generate_reused_concepts_ or cls.rawTags['class-usage-scope'] == "main" %}
+      {% if cls.classType == "definition" %}
+| {{ cls.name }} | {{ passthrough_if_external_concept(cls.description.en) }}
+      {% endif %}
+    {% endif %}
+  {%- endif -%}
 {% endfor %}
 |===
 

--- a/src/rspec-cfg-json-generate.xsl
+++ b/src/rspec-cfg-json-generate.xsl
@@ -34,7 +34,10 @@
                     'classReferenceRespecLabel': string($classReferenceRespecLabel),
                     'showReferencesInRespec': boolean($showReferencesInRespec),
                     'mandatoryStatusTagName': string($mandatoryStatusTagName),
-                    'usageNoteTagName': string($usageNoteTagName)
+                    'usageNoteTagName': string($usageNoteTagName),
+                    'statusProperty': string($statusProperty),
+                    'unspecifiedStatusInterpretation': string($unspecifiedStatusInterpretation),
+                    'excludedElementStatusesList': array { $excludedElementStatusesList }
                 }
             }"/>
 


### PR DESCRIPTION
Scope of changes:
* Extended `generate-asciidoc-glossary` recipe to generate and integrate config JSON with parameters controlling status-based filtering
* Extended generation of config JSON to contain config parameters for status-based filtering
* Updated Jinja tempate with conditions on the element status